### PR TITLE
Generate direct-download calendar PDFs and expand calendar layout

### DIFF
--- a/src/Controller/CalendarController.php
+++ b/src/Controller/CalendarController.php
@@ -58,7 +58,7 @@ class CalendarController extends AppController
         $pdf->SetFont('Arial', 'B', 18);
         $pdf->SetTextColor(68, 68, 68);
         $pdf->SetXY(12, 10);
-        $pdf->Cell(0, 10, utf8_decode($title), 0, 1, 'L');
+        $pdf->Cell(0, 10, $this->pdfText($title), 0, 1, 'L');
 
         $this->drawLegend($pdf, 12, 22);
     }
@@ -80,7 +80,7 @@ class CalendarController extends AppController
             $pdf->SetFillColor($item['color'][0], $item['color'][1], $item['color'][2]);
             $pdf->Rect($itemX, $y + 1, 4, 4, 'DF');
             $pdf->SetXY($itemX + 6, $y);
-            $pdf->Cell(35, 6, utf8_decode($item['label']), 0, 0, 'L');
+            $pdf->Cell(35, 6, $this->pdfText((string)$item['label']), 0, 0, 'L');
             $itemX += 46;
         }
     }
@@ -126,7 +126,7 @@ class CalendarController extends AppController
         $pdf->SetFont('Arial', 'B', 9);
         $pdf->SetTextColor(255, 255, 255);
         $pdf->SetXY($x, $y + 1.5);
-        $pdf->Cell($width, 4, utf8_decode((string)$month['label']), 0, 0, 'C');
+        $pdf->Cell($width, 4, $this->pdfText((string)$month['label']), 0, 0, 'C');
 
         $tableY = $y + $headerHeight;
         $cellWidth = $width / 7;
@@ -183,6 +183,17 @@ class CalendarController extends AppController
             'calendar-day--closed' => [244, 244, 246],
             default => [255, 255, 255],
         };
+    }
+
+    private function pdfText(string $text): string
+    {
+        if ($text === '') {
+            return '';
+        }
+
+        $converted = iconv('UTF-8', 'windows-1252//TRANSLIT//IGNORE', $text);
+
+        return $converted === false ? $text : $converted;
     }
 
     /**

--- a/src/Controller/CalendarController.php
+++ b/src/Controller/CalendarController.php
@@ -6,6 +6,7 @@ namespace App\Controller;
 
 use Cake\Http\Exception\NotFoundException;
 use Cake\I18n\FrozenDate;
+use setasign\Fpdi\Fpdi;
 
 class CalendarController extends AppController
 {
@@ -16,14 +17,172 @@ class CalendarController extends AppController
 
     public function pdfAnnual(): void
     {
-        $this->viewBuilder()->disableAutoLayout();
-        $this->set($this->calendarData());
+        $calendar = $this->calendarData();
+        $pdf = new Fpdi('L', 'mm', 'A4');
+        $pdf->SetAutoPageBreak(false);
+        $pdf->AddPage();
+
+        $this->renderPdfHeader($pdf, $calendar['courseLabel']);
+        $this->renderAnnualMonths($pdf, $calendar['months']);
+
+        $this->respondPdfDownload($pdf, sprintf('calendari-anual-%s.pdf', strtolower(str_replace(' ', '-', $calendar['courseLabel']))));
     }
 
     public function pdfMonthly(): void
     {
-        $this->viewBuilder()->disableAutoLayout();
-        $this->set($this->calendarData());
+        $calendar = $this->calendarData();
+        $pdf = new Fpdi('P', 'mm', 'A4');
+        $pdf->SetAutoPageBreak(false);
+
+        foreach ($calendar['months'] as $month) {
+            $pdf->AddPage();
+            $this->renderPdfHeader($pdf, sprintf('%s · %s', $calendar['courseLabel'], $month['label']));
+            $this->renderSingleMonth($pdf, $month, 20, 35, 170, 240);
+        }
+
+        $this->respondPdfDownload($pdf, sprintf('calendari-mensual-%s.pdf', strtolower(str_replace(' ', '-', $calendar['courseLabel']))));
+    }
+
+    private function respondPdfDownload(Fpdi $pdf, string $filename): void
+    {
+        $content = $pdf->Output('S');
+        $this->response = $this->response
+            ->withType('pdf')
+            ->withHeader('Content-Disposition', 'attachment; filename="' . $filename . '"')
+            ->withStringBody($content);
+        $this->autoRender = false;
+    }
+
+    private function renderPdfHeader(Fpdi $pdf, string $title): void
+    {
+        $pdf->SetFont('Arial', 'B', 18);
+        $pdf->SetTextColor(68, 68, 68);
+        $pdf->SetXY(12, 10);
+        $pdf->Cell(0, 10, utf8_decode($title), 0, 1, 'L');
+
+        $this->drawLegend($pdf, 12, 22);
+    }
+
+    private function drawLegend(Fpdi $pdf, float $x, float $y): void
+    {
+        $legend = [
+            ['label' => 'Obert (lectiu)', 'color' => [255, 255, 255]],
+            ['label' => 'Obert (no lectiu)', 'color' => [252, 229, 205]],
+            ['label' => 'Festiu', 'color' => [244, 204, 204]],
+            ['label' => 'Tancat', 'color' => [244, 244, 246]],
+        ];
+
+        $pdf->SetFont('Arial', '', 9);
+        $itemX = $x;
+
+        foreach ($legend as $item) {
+            $pdf->SetDrawColor(178, 171, 191);
+            $pdf->SetFillColor($item['color'][0], $item['color'][1], $item['color'][2]);
+            $pdf->Rect($itemX, $y + 1, 4, 4, 'DF');
+            $pdf->SetXY($itemX + 6, $y);
+            $pdf->Cell(35, 6, utf8_decode($item['label']), 0, 0, 'L');
+            $itemX += 46;
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $months
+     */
+    private function renderAnnualMonths(Fpdi $pdf, array $months): void
+    {
+        $startX = 12;
+        $startY = 32;
+        $cols = 4;
+        $gapX = 4;
+        $gapY = 6;
+        $monthWidth = 67;
+        $monthHeight = 58;
+
+        foreach ($months as $idx => $month) {
+            $col = $idx % $cols;
+            $row = intdiv($idx, $cols);
+
+            $x = $startX + $col * ($monthWidth + $gapX);
+            $y = $startY + $row * ($monthHeight + $gapY);
+
+            $this->renderSingleMonth($pdf, $month, $x, $y, $monthWidth, $monthHeight);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $month
+     */
+    private function renderSingleMonth(Fpdi $pdf, array $month, float $x, float $y, float $width, float $height): void
+    {
+        $headerHeight = 7;
+        $weekHeaderHeight = 6;
+        $days = ['dl', 'dt', 'dc', 'dj', 'dv', 'ds', 'dg'];
+
+        $pdf->SetDrawColor(178, 171, 191);
+        $pdf->SetLineWidth(0.25);
+
+        $pdf->SetFillColor(178, 171, 191);
+        $pdf->Rect($x, $y, $width, $headerHeight, 'DF');
+        $pdf->SetFont('Arial', 'B', 9);
+        $pdf->SetTextColor(255, 255, 255);
+        $pdf->SetXY($x, $y + 1.5);
+        $pdf->Cell($width, 4, utf8_decode((string)$month['label']), 0, 0, 'C');
+
+        $tableY = $y + $headerHeight;
+        $cellWidth = $width / 7;
+        $rows = 7;
+        $cellHeight = ($height - $headerHeight) / $rows;
+
+        $pdf->SetFont('Arial', 'B', 7);
+        $pdf->SetFillColor(228, 223, 238);
+        $pdf->SetTextColor(67, 67, 67);
+        foreach ($days as $i => $day) {
+            $cellX = $x + ($i * $cellWidth);
+            $pdf->Rect($cellX, $tableY, $cellWidth, $weekHeaderHeight, 'DF');
+            $pdf->SetXY($cellX, $tableY + 1.5);
+            $pdf->Cell($cellWidth, 3, $day, 0, 0, 'C');
+        }
+
+        $weeks = $month['weeks'];
+        for ($row = 0; $row < 6; $row++) {
+            $week = $weeks[$row] ?? array_fill(0, 7, null);
+            for ($col = 0; $col < 7; $col++) {
+                $day = $week[$col] ?? null;
+                $cellX = $x + ($col * $cellWidth);
+                $cellY = $tableY + $weekHeaderHeight + ($row * $cellHeight);
+
+                if ($day === null) {
+                    $pdf->SetFillColor(255, 255, 255);
+                } else {
+                    [$r, $g, $b] = $this->dayColor((string)$day['class']);
+                    $pdf->SetFillColor($r, $g, $b);
+                }
+
+                $pdf->Rect($cellX, $cellY, $cellWidth, $cellHeight, 'F');
+
+                if ($day !== null) {
+                    $pdf->SetFont('Arial', '', 7);
+                    $pdf->SetTextColor(67, 67, 67);
+                    $pdf->SetXY($cellX, $cellY + 1.4);
+                    $pdf->Cell($cellWidth, 3, (string)$day['number'], 0, 0, 'C');
+                }
+            }
+        }
+
+        $pdf->Rect($x, $y, $width, $height, 'D');
+    }
+
+    /**
+     * @return array{0:int,1:int,2:int}
+     */
+    private function dayColor(string $class): array
+    {
+        return match ($class) {
+            'calendar-day--festiu' => [244, 204, 204],
+            'calendar-day--obert' => [252, 229, 205],
+            'calendar-day--closed' => [244, 244, 246],
+            default => [255, 255, 255],
+        };
     }
 
     /**

--- a/templates/element/calendar.php
+++ b/templates/element/calendar.php
@@ -221,13 +221,13 @@ echo $this->Html->css('calendar', ['block' => true]);
         <?= $this->Html->link(
             __('Descarrega calendari anual (PDF)'),
             ['controller' => 'Calendar', 'action' => 'pdfAnnual'],
-            ['class' => 'annual-calendar__action-btn', 'target' => '_blank', 'rel' => 'noopener']
+            ['class' => 'annual-calendar__action-btn']
         ) ?>
 
         <?= $this->Html->link(
             __('Descarrega calendari mensual (PDF)'),
             ['controller' => 'Calendar', 'action' => 'pdfMonthly'],
-            ['class' => 'annual-calendar__action-btn', 'target' => '_blank', 'rel' => 'noopener']
+            ['class' => 'annual-calendar__action-btn']
         ) ?>
     </div>
 </section>

--- a/webroot/css/calendar.css
+++ b/webroot/css/calendar.css
@@ -22,8 +22,9 @@ body::after {
   align-items: start;
 
   /* “marges” tipus document */
-  max-width: 1100px;
-  margin: 0 auto;
+  width: 100%;
+  max-width: none;
+  margin: 0;
   padding: 28px 28px 36px;
 
   font-family: "Roboto Condensed", "Roboto", Arial, sans-serif;
@@ -105,7 +106,7 @@ body::after {
 /* Grid mesos (estructura igual, només look) */
 .annual-calendar__months {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 1.1rem;
 }
 
@@ -288,9 +289,9 @@ body::after {
   height: 1rem;
 }
 
-/* 3 columnes fixes per als mesos */
+/* 4 columnes fixes per als mesos */
 .annual-calendar__months {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
 /* Botons de descàrrega PDF */
@@ -326,7 +327,7 @@ body::after {
 
 @media (max-width: 1200px) {
   .annual-calendar__months {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 

--- a/webroot/css/calendar.css
+++ b/webroot/css/calendar.css
@@ -17,7 +17,6 @@ body::after {
 /* Contenidor */
 .annual-calendar {
   display: grid;
-  grid-template-columns: minmax(220px, 260px) 1fr;
   gap: 2.5rem;
   align-items: start;
 

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -121,9 +121,16 @@
 
   /* main no ha de tornar a sumar top/margin */
   .app-main{
-    padding-top: -1rem;
-    margin-left: 5rem;
-    margin-right: 5rem;
+    padding-top: 0;
+    margin-left: 1.5rem;
+    margin-right: 1.5rem;
+  }
+
+  .app-container{
+    width: 100%;
+    max-width: none;
+    margin: 0;
+    padding: 0;
   }
 
   .app-sidebar__close{


### PR DESCRIPTION
### Motivation
- Provide users with immediately downloadable PDF exports for the calendar instead of relying on a browser print view. 
- Make the on-page calendar occupy the available horizontal space so the months are not cramped. 

### Description
- Replaced the print-view responses in `CalendarController::pdfAnnual()` and `pdfMonthly()` with server-side PDF generation using `FPDI/FPDF` and added `use setasign\Fpdi\Fpdi;`.
- Added PDF helper methods in `src/Controller/CalendarController.php` to build headers, legend, month grids, single-month rendering and a `dayColor()` mapper, and a `respondPdfDownload()` helper that returns `application/pdf` with `Content-Disposition: attachment`.
- Adjusted the calendar element view `templates/element/calendar.php` to remove `_blank`/`rel` attributes so the links trigger direct download behavior.
- Widened the calendar layout in `webroot/css/calendar.css` to use full available width and a denser month grid (4 columns on large screens, 3 on medium). 

### Testing
- Ran PHP lint checks with `php -l src/Controller/CalendarController.php` and `php -l templates/element/calendar.php`, both succeeded.
- Attempted `composer install --no-interaction --prefer-dist` but it failed in this environment because the project's lockfile requires PHP versions incompatible with the container's PHP (8.5), so `vendor/autoload.php` was not available.
- Tried to start a local dev server (`php -S 0.0.0.0:8080 -t webroot`) and request the PDF endpoints, but requests returned `500` because dependencies were missing (no `vendor/autoload.php`) due to the composer failure.
- Static validation and a headless screenshot of `/calendar` were attempted, but full runtime verification of PDF output could not be completed in this environment because dependencies could not be installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69942156ffbc832a94461e1a8bfb2768)