### PR TITLE
Main top-alignment by default; center for menuppal; pestanya scroll + wheel-nav

### DIFF
--- a/templates/Pagines/view.php
+++ b/templates/Pagines/view.php
@@ -8,6 +8,12 @@ $this->assign('title', $pagina->title ?? 'Pàgina');
 
 $body = (string)($pagina->body ?? '');
 
+
+$hasMainMenu = preg_match('/(?:\{|\&\#123;)\s*menuppal\s*(?:\}|\&\#125;)/i', $body) === 1;
+if ($hasMainMenu) {
+    $this->assign('appMainClass', 'app-main--centered');
+}
+
 if ($body !== '') {
     // Regex que captura:
     //  - {element}

--- a/templates/layout/default.php
+++ b/templates/layout/default.php
@@ -55,6 +55,7 @@ $pageLevel = function (string $orderCode): int {
     <?= $this->fetch('script') ?>
 </head>
 <body>
+<?php $mainClass = trim('app-main ' . $this->fetch('appMainClass')); ?>
 
 <!-- TOPBAR -->
 <header class="app-topbar" id="appTopbar">
@@ -172,7 +173,7 @@ $pageLevel = function (string $orderCode): int {
     </aside>
 
     <!-- CONTINGUT -->
-    <main class="app-main">
+    <main class="<?= h($mainClass) ?>">
         <div class="app-container">
             <?= $this->Flash->render() ?>
             <?= $this->fetch('content') ?>
@@ -238,6 +239,69 @@ $pageLevel = function (string $orderCode): int {
         if (e.key === 'Escape' && document.body.classList.contains('sidebar-open')) {
             closeSidebar();
         }
+    });
+})();
+
+(function () {
+    const EDGE_TOLERANCE = 2;
+    const CHANGE_COOLDOWN_MS = 450;
+    let lastChangeTime = 0;
+
+    function getVisiblePestanyes() {
+        return Array.from(document.querySelectorAll('.pestanya')).filter((panel) => {
+            const style = window.getComputedStyle(panel);
+            return style.display !== 'none' && style.visibility !== 'hidden';
+        });
+    }
+
+    function activateNextPanel(currentPanel, direction) {
+        const now = Date.now();
+        if (now - lastChangeTime < CHANGE_COOLDOWN_MS) {
+            return false;
+        }
+
+        const panels = getVisiblePestanyes();
+        const index = panels.indexOf(currentPanel);
+        if (index < 0) {
+            return false;
+        }
+
+        const target = direction > 0 ? panels[index + 1] : panels[index - 1];
+        if (!target) {
+            return false;
+        }
+
+        lastChangeTime = now;
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+        const targetText = target.querySelector('.text');
+        if (targetText) {
+            targetText.scrollTop = direction > 0 ? 0 : targetText.scrollHeight;
+        }
+
+        return true;
+    }
+
+    document.querySelectorAll('.pestanya .text').forEach((scrollBox) => {
+        scrollBox.addEventListener('wheel', (event) => {
+            const panel = scrollBox.closest('.pestanya');
+            if (!panel) {
+                return;
+            }
+
+            const atTop = scrollBox.scrollTop <= EDGE_TOLERANCE;
+            const atBottom = scrollBox.scrollTop + scrollBox.clientHeight >= scrollBox.scrollHeight - EDGE_TOLERANCE;
+            const scrollingDown = event.deltaY > 0;
+            const scrollingUp = event.deltaY < 0;
+
+            if (scrollingDown && atBottom && activateNextPanel(panel, 1)) {
+                event.preventDefault();
+            }
+
+            if (scrollingUp && atTop && activateNextPanel(panel, -1)) {
+                event.preventDefault();
+            }
+        }, { passive: false });
     });
 })();
 </script>

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -244,7 +244,7 @@ body{ margin: 0; }
     height: calc(100vh - var(--topbar-h-desktop) - var(--bottombar-h-desktop));
 
     display: flex;              /* ← clau */
-    align-items: center;
+    align-items: flex-start;
 
     overflow-y: auto;
 
@@ -257,6 +257,10 @@ body{ margin: 0; }
     max-width: none;
     margin: 0;
     padding: 16px;
+  }
+
+  .app-main.app-main--centered{
+    align-items: center;
   }
 
   /* BOTTOMBAR fixa (10vh) i 3 columnes, alineades a dalt */

--- a/webroot/css/pestanya.css
+++ b/webroot/css/pestanya.css
@@ -1,11 +1,13 @@
 /* PESTANYES GENERALS */
 .pestanya {
-    display: block;
+    display: flex;
+    flex-direction: column;
     max-width: 1000px;
     width: 100%;
     margin: 1rem auto;
     opacity: 1;
     transform: translateX(0);
+    max-height: calc(100vh - var(--topbar-h-desktop) - var(--bottombar-h-desktop) - 2rem);
 }
 
 /* Animació opcional: només si es vol aplicar explícitament */
@@ -45,6 +47,8 @@
     border-radius: 0;
     margin-top: 0;
     text-align: left;
+    overflow-y: auto;
+    overscroll-behavior: contain;
 }
 
 .pestanya .text ul {
@@ -175,3 +179,9 @@
 .pestanya-grisclar .text ol li::before,
 .pestanya-grisclar .text ul li::before { background-color: #cfcfcf; }
 .pestanya-grisclar .text { border-color: #cfcfcf; }
+
+@media (max-width: 900px) {
+    .pestanya {
+        max-height: calc(100vh - var(--topbar-h-mobile) - 2rem);
+    }
+}


### PR DESCRIPTION
### Motivation
- Pages with the `{menuppal}` element need the sidebar/menu centered vertically inside `main`, while other pages should align content to the top to avoid content being clipped (e.g. the `cursos` element). 
- When a tab/pestanya is taller than the available main area, its framing should stay inside `main` and its content should scroll internally instead of being cut off. 
- Provide a natural UX where continued wheel scrolling at a pestanya's top/bottom jumps to the previous/next pestanya.

### Description
- Detect presence of `{menuppal}` in page body and set an `app-main--centered` class via `templates/Pagines/view.php` so centering applies only on requested pages. 
- Use the new `appMainClass` in `templates/layout/default.php` to render `<main>` with the conditional class and add a small wheel-handler script that, when a `.pestanya .text` scroll hits the top/bottom and the user keeps scrolling, navigates to the previous/next visible `.pestanya` (with a short cooldown). 
- Change layout behaviour in `webroot/css/layout_custom.css` to make `main` top-aligned by default (`align-items: flex-start`) and add `.app-main.app-main--centered{ align-items: center; }` for the `{menuppal}` case. 
- Constrain `.pestanya` height and enable internal scrolling by updating `webroot/css/pestanya.css` to use flex layout, a `max-height` that fits the main viewport, `overflow-y: auto` on `.pestanya .text`, `overscroll-behavior: contain`, and a mobile `max-height` rule.

### Testing
- Ran PHP syntax checks with `php -l templates/layout/default.php` and `php -l templates/Pagines/view.php`, both succeeded. 
- Launched a local PHP dev server with `php -S 0.0.0.0:8000 -t webroot` to validate runtime wiring, which started successfully. 
- Attempted a Playwright screenshot to capture visual verification, but the Chromium process crashed (SIGSEGV) in this environment so no screenshot could be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d80e47dc4832abb388d65c3c64007)