### PR TITLE
Ajusta l'alineació vertical del contingut al main

### DIFF
--- a/templates/Pagines/view.php
+++ b/templates/Pagines/view.php
@@ -7,6 +7,11 @@
 $this->assign('title', $pagina->title ?? 'Pàgina');
 
 $body = (string)($pagina->body ?? '');
+$hasMenuppal = preg_match('/(?:\{|\&\#123;)\s*menuppal\s*(?:\}|\&\#125;)/i', $body) === 1;
+
+if ($hasMenuppal) {
+    $this->assign('appMainClass', 'app-main app-main--centered');
+}
 
 if ($body !== '') {
     // Regex que captura:

--- a/templates/element/cursos.php
+++ b/templates/element/cursos.php
@@ -316,7 +316,7 @@ foreach ($courses as $course) {
 
 <div class="cursos-element" id="cursos-top">
     <div class="cursos-tabs">
-        <?php foreach ($courses as $course): ?>
+        <?php foreach ($courses as $courseIndex => $course): ?>
             <?php
             $courseAnchor = 'course-' . (int)$course->id;
             $courseTitleLink = '<a href="#' . h($courseAnchor) . '" class="cursos-title-link">' . h((string)$course->name) . '</a>';
@@ -439,7 +439,7 @@ foreach ($courses as $course) {
             $subjectKey = (int)($course->subject_id ?? 0);
             $subjectColor = $subjectColors[$subjectKey] ?? $colors[0];
             ?>
-            <div id="<?= h($courseAnchor) ?>" class="cursos-tab-item is-visible" data-subject="<?= h((string)$subjectKey) ?>">
+            <div id="<?= h($courseAnchor) ?>" class="cursos-tab-item <?= $courseIndex === 0 ? 'is-visible' : '' ?>" data-subject="<?= h((string)$subjectKey) ?>">
                 <?= $this->element('pestanya', [
                     'titol' => (string)$course->name,
                     'titolHtml' => $courseTitleLink,
@@ -459,8 +459,12 @@ foreach ($courses as $course) {
 }
 
 .cursos-tab-item {
-    display: block;
+    display: none;
     scroll-margin-top: 10.5rem;
+}
+
+.cursos-tab-item.is-visible {
+    display: block;
 }
 
 .cursos-element .horari-linia {
@@ -522,6 +526,33 @@ foreach ($courses as $course) {
 
 <script>
 (function () {
+    const tabItems = Array.from(document.querySelectorAll('.cursos-tab-item'));
+    if (tabItems.length === 0) {
+        return;
+    }
+
+    let activeIndex = Math.max(0, tabItems.findIndex((item) => item.classList.contains('is-visible')));
+    let isNavigating = false;
+    let touchStartY = null;
+
+    const setActive = (index) => {
+        const normalized = ((index % tabItems.length) + tabItems.length) % tabItems.length;
+        tabItems.forEach((item, idx) => item.classList.toggle('is-visible', idx === normalized));
+        activeIndex = normalized;
+        tabItems[activeIndex].scrollIntoView({ behavior: 'smooth', block: 'start' });
+    };
+
+    const navigate = (direction) => {
+        if (isNavigating || direction === 0) {
+            return;
+        }
+        isNavigating = true;
+        setActive(activeIndex + direction);
+        window.setTimeout(() => {
+            isNavigating = false;
+        }, 450);
+    };
+
     document.querySelectorAll('.cursos-compatible-toggle').forEach((toggle) => {
         toggle.addEventListener('click', function (event) {
             event.preventDefault();
@@ -538,5 +569,63 @@ foreach ($courses as $course) {
             list.classList.toggle('is-open');
         });
     });
+
+    document.querySelectorAll('.cursos-title-link').forEach((link) => {
+        link.addEventListener('click', function (event) {
+            const href = this.getAttribute('href') || '';
+            if (!href.startsWith('#course-')) {
+                return;
+            }
+
+            event.preventDefault();
+            const target = document.querySelector(href);
+            if (!target) {
+                return;
+            }
+
+            const nextIndex = tabItems.indexOf(target);
+            if (nextIndex !== -1) {
+                setActive(nextIndex);
+            }
+        });
+    });
+
+    window.addEventListener('wheel', (event) => {
+        const active = tabItems[activeIndex];
+        const scrollPanel = active?.querySelector('.pestanya .text');
+        if (!scrollPanel) {
+            return;
+        }
+
+        const atTop = scrollPanel.scrollTop <= 0;
+        const atBottom = scrollPanel.scrollTop + scrollPanel.clientHeight >= scrollPanel.scrollHeight - 1;
+        if (event.deltaY > 0 && atBottom) {
+            event.preventDefault();
+            navigate(1);
+        } else if (event.deltaY < 0 && atTop) {
+            event.preventDefault();
+            navigate(-1);
+        }
+    }, { passive: false });
+
+    window.addEventListener('touchstart', (event) => {
+        touchStartY = event.touches[0]?.clientY ?? null;
+    }, { passive: true });
+
+    window.addEventListener('touchend', (event) => {
+        if (touchStartY === null) {
+            return;
+        }
+
+        const endY = event.changedTouches[0]?.clientY ?? touchStartY;
+        const deltaY = touchStartY - endY;
+        touchStartY = null;
+
+        if (Math.abs(deltaY) < 40) {
+            return;
+        }
+
+        navigate(deltaY > 0 ? 1 : -1);
+    }, { passive: true });
 })();
 </script>

--- a/templates/element/pestanya.php
+++ b/templates/element/pestanya.php
@@ -31,48 +31,6 @@ $classes = trim("pestanya pestanya-{$color} {$extraClass}");
 ?>
 
 <div class="<?= h($classes) ?>">
-    <div class="pestanya-capcalera">
-        <div class="titol"><?= $titolHtml !== '' ? $titolHtml : h($titol) ?></div>
-        <div class="pestanya-nav" aria-label="Navegació de pestanyes">
-            <button type="button" class="pestanya-nav-btn pestanya-nav-btn--prev" aria-label="Pestanya anterior">&#9664;</button>
-            <button type="button" class="pestanya-nav-btn pestanya-nav-btn--next" aria-label="Pestanya següent">&#9654;</button>
-        </div>
-    </div>
+    <div class="titol"><?= $titolHtml !== '' ? $titolHtml : h($titol) ?></div>
     <div class="text"><?= $contingut ?></div>
 </div>
-
-<script>
-(function () {
-    if (window.__pestanyaNavReady) {
-        return;
-    }
-    window.__pestanyaNavReady = true;
-
-    document.addEventListener('click', function (event) {
-        const button = event.target.closest('.pestanya-nav-btn');
-        if (!button) {
-            return;
-        }
-
-        const tabItem = button.closest('.cursos-tab-item');
-        if (!tabItem) {
-            return;
-        }
-
-        const direction = button.classList.contains('pestanya-nav-btn--prev') ? -1 : 1;
-        let sibling = tabItem;
-
-        do {
-            sibling = direction < 0 ? sibling.previousElementSibling : sibling.nextElementSibling;
-        } while (sibling && !sibling.classList.contains('cursos-tab-item'));
-
-        if (!sibling) {
-            sibling = direction < 0
-                ? tabItem.parentElement.querySelector('.cursos-tab-item:last-child')
-                : tabItem.parentElement.querySelector('.cursos-tab-item:first-child');
-        }
-
-        sibling?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    });
-})();
-</script>

--- a/templates/element/pestanya.php
+++ b/templates/element/pestanya.php
@@ -31,6 +31,48 @@ $classes = trim("pestanya pestanya-{$color} {$extraClass}");
 ?>
 
 <div class="<?= h($classes) ?>">
-    <div class="titol"><?= $titolHtml !== '' ? $titolHtml : h($titol) ?></div>
+    <div class="pestanya-capcalera">
+        <div class="titol"><?= $titolHtml !== '' ? $titolHtml : h($titol) ?></div>
+        <div class="pestanya-nav" aria-label="Navegació de pestanyes">
+            <button type="button" class="pestanya-nav-btn pestanya-nav-btn--prev" aria-label="Pestanya anterior">&#9664;</button>
+            <button type="button" class="pestanya-nav-btn pestanya-nav-btn--next" aria-label="Pestanya següent">&#9654;</button>
+        </div>
+    </div>
     <div class="text"><?= $contingut ?></div>
 </div>
+
+<script>
+(function () {
+    if (window.__pestanyaNavReady) {
+        return;
+    }
+    window.__pestanyaNavReady = true;
+
+    document.addEventListener('click', function (event) {
+        const button = event.target.closest('.pestanya-nav-btn');
+        if (!button) {
+            return;
+        }
+
+        const tabItem = button.closest('.cursos-tab-item');
+        if (!tabItem) {
+            return;
+        }
+
+        const direction = button.classList.contains('pestanya-nav-btn--prev') ? -1 : 1;
+        let sibling = tabItem;
+
+        do {
+            sibling = direction < 0 ? sibling.previousElementSibling : sibling.nextElementSibling;
+        } while (sibling && !sibling.classList.contains('cursos-tab-item'));
+
+        if (!sibling) {
+            sibling = direction < 0
+                ? tabItem.parentElement.querySelector('.cursos-tab-item:last-child')
+                : tabItem.parentElement.querySelector('.cursos-tab-item:first-child');
+        }
+
+        sibling?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+})();
+</script>

--- a/templates/layout/default.php
+++ b/templates/layout/default.php
@@ -36,6 +36,10 @@ $pageLevel = function (string $orderCode): int {
     $orderCode = trim($orderCode);
     return $orderCode === '' ? 1 : count(explode('.', $orderCode));
 };
+$appMainClass = trim((string)$this->fetch('appMainClass'));
+if ($appMainClass === '') {
+    $appMainClass = 'app-main';
+}
 ?>
 <!DOCTYPE html>
 <html lang="ca">
@@ -172,7 +176,7 @@ $pageLevel = function (string $orderCode): int {
     </aside>
 
     <!-- CONTINGUT -->
-    <main class="app-main">
+    <main class="<?= h($appMainClass) ?>">
         <div class="app-container">
             <?= $this->Flash->render() ?>
             <?= $this->fetch('content') ?>

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -244,7 +244,7 @@ body{ margin: 0; }
     height: calc(100vh - var(--topbar-h-desktop) - var(--bottombar-h-desktop));
 
     display: flex;              /* ← clau */
-    align-items: center;
+    align-items: flex-start;
 
     overflow-y: auto;
 
@@ -252,6 +252,10 @@ body{ margin: 0; }
     padding: 0;
   }
 
+
+  .app-main.app-main--centered{
+    align-items: center;
+  }
   .app-container{
     width: 100%;
     max-width: none;

--- a/webroot/css/pestanya.css
+++ b/webroot/css/pestanya.css
@@ -1,11 +1,36 @@
 /* PESTANYES GENERALS */
 .pestanya {
+    --pestanya-color: #cfcfcf;
     display: block;
     max-width: 1000px;
     width: 100%;
     margin: 1rem auto;
     opacity: 1;
     transform: translateX(0);
+}
+
+.pestanya-capcalera {
+    display: flex;
+    align-items: stretch;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.pestanya-nav {
+    display: inline-flex;
+    gap: 0.35rem;
+}
+
+.pestanya-nav-btn {
+    width: 3.5rem;
+    min-width: 3.5rem;
+    border: 0;
+    border-radius: 0;
+    background: var(--pestanya-color);
+    color: #fff;
+    font-size: 1.3rem;
+    line-height: 1;
+    cursor: pointer;
 }
 
 /* Animació opcional: només si es vol aplicar explícitament */
@@ -23,6 +48,7 @@
 /* Títol */
 .pestanya .titol {
     display: inline-block;
+    flex: 1;
     padding: 0.75rem 1rem;
     color: white;
     font-family: 'Bebas Neue', sans-serif;
@@ -45,6 +71,54 @@
     border-radius: 0;
     margin-top: 0;
     text-align: left;
+    max-height: 70vh;
+    overflow: auto;
+    scrollbar-width: auto;
+    scrollbar-color: var(--pestanya-color) #fff;
+}
+
+@media (min-width: 901px) {
+    .pestanya .text {
+        max-height: calc((100vh - var(--topbar-h-desktop) - var(--bottombar-h-desktop)) * 0.7);
+    }
+}
+
+@media (max-width: 900px) {
+    .pestanya .text {
+        max-height: calc((100vh - var(--topbar-h-mobile)) * 0.7);
+    }
+}
+
+.pestanya .text::-webkit-scrollbar {
+    width: 16px;
+}
+
+.pestanya .text::-webkit-scrollbar-track {
+    background: #fff;
+}
+
+.pestanya .text::-webkit-scrollbar-thumb {
+    background: var(--pestanya-color);
+    border-radius: 0;
+    border: 0;
+}
+
+.pestanya .text::-webkit-scrollbar-button:single-button {
+    display: block;
+    height: 16px;
+    background: var(--pestanya-color);
+    border-radius: 0;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 9px 9px;
+}
+
+.pestanya .text::-webkit-scrollbar-button:single-button:vertical:decrement {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='9' height='9' viewBox='0 0 9 9'%3E%3Cpath d='M4.5 1 L8 6 H1 Z' fill='white'/%3E%3C/svg%3E");
+}
+
+.pestanya .text::-webkit-scrollbar-button:single-button:vertical:increment {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='9' height='9' viewBox='0 0 9 9'%3E%3Cpath d='M1 3 L8 3 L4.5 8 Z' fill='white'/%3E%3C/svg%3E");
 }
 
 .pestanya .text ul {
@@ -125,52 +199,62 @@
 /* Responsive */
 @media (max-width: 767px) {
     .pestanya { width: 100%; }
+    .pestanya-nav-btn { width: 2.8rem; min-width: 2.8rem; }
     .pestanya .titol { font-size: 1.5rem; }
     .pestanya .text { font-size: 1.1rem; padding: 1.2rem; }
     .pestanya .text ol li::before { font-size: 0.8rem; line-height: 1.2rem; }
 }
 
 /* COLORS (els de sempre) */
+.pestanya-rosa { --pestanya-color: #e55381; }
 .pestanya-rosa .titol,
 .pestanya-rosa .text ol li::before,
 .pestanya-rosa .text ul li::before { background-color: #e55381; }
 .pestanya-rosa .text { border-color: #e55381; }
 
+.pestanya-blaucel { --pestanya-color: #8ec3c3; }
 .pestanya-blaucel .titol,
 .pestanya-blaucel .text ol li::before,
 .pestanya-blaucel .text ul li::before { background-color: #8ec3c3; }
 .pestanya-blaucel .text { border-color: #8ec3c3; }
 
+.pestanya-lila { --pestanya-color: #b2abbe; }
 .pestanya-lila .titol,
 .pestanya-lila .text ol li::before,
 .pestanya-lila .text ul li::before { background-color: #b2abbe; }
 .pestanya-lila .text { border-color: #b2abbe; }
 
+.pestanya-taronja { --pestanya-color: #feb20e; }
 .pestanya-taronja .titol,
 .pestanya-taronja .text ol li::before,
 .pestanya-taronja .text ul li::before { background-color: #feb20e; }
 .pestanya-taronja .text { border-color: #feb20e; }
 
+.pestanya-blaumari { --pestanya-color: #708090; }
 .pestanya-blaumari .titol,
 .pestanya-blaumari .text ol li::before,
 .pestanya-blaumari .text ul li::before { background-color: #708090; }
 .pestanya-blaumari .text { border-color: #708090; }
 
+.pestanya-verd { --pestanya-color: #aed581; }
 .pestanya-verd .titol,
 .pestanya-verd .text ol li::before,
 .pestanya-verd .text ul li::before { background-color: #aed581; }
 .pestanya-verd .text { border-color: #aed581; }
 
+.pestanya-gris { --pestanya-color: #bfbfbf; }
 .pestanya-gris .titol,
 .pestanya-gris .text ol li::before,
 .pestanya-gris .text ul li::before { background-color: #bfbfbf; }
 .pestanya-gris .text { border-color: #bfbfbf; }
 
+.pestanya-ocre { --pestanya-color: #d8baa9; }
 .pestanya-ocre .titol,
 .pestanya-ocre .text ol li::before,
 .pestanya-ocre .text ul li::before { background-color: #d8baa9; }
 .pestanya-ocre .text { border-color: #d8baa9; }
 
+.pestanya-grisclar { --pestanya-color: #cfcfcf; }
 .pestanya-grisclar .titol,
 .pestanya-grisclar .text ol li::before,
 .pestanya-grisclar .text ul li::before { background-color: #cfcfcf; }

--- a/webroot/css/pestanya.css
+++ b/webroot/css/pestanya.css
@@ -9,29 +9,6 @@
     transform: translateX(0);
 }
 
-.pestanya-capcalera {
-    display: flex;
-    align-items: stretch;
-    justify-content: space-between;
-    gap: 0.5rem;
-}
-
-.pestanya-nav {
-    display: inline-flex;
-    gap: 0.35rem;
-}
-
-.pestanya-nav-btn {
-    width: 3.5rem;
-    min-width: 3.5rem;
-    border: 0;
-    border-radius: 0;
-    background: var(--pestanya-color);
-    color: #fff;
-    font-size: 1.3rem;
-    line-height: 1;
-    cursor: pointer;
-}
 
 /* Animació opcional: només si es vol aplicar explícitament */
 .pestanya.animable {
@@ -199,7 +176,7 @@
 /* Responsive */
 @media (max-width: 767px) {
     .pestanya { width: 100%; }
-    .pestanya-nav-btn { width: 2.8rem; min-width: 2.8rem; }
+
     .pestanya .titol { font-size: 1.5rem; }
     .pestanya .text { font-size: 1.1rem; padding: 1.2rem; }
     .pestanya .text ol li::before { font-size: 0.8rem; line-height: 1.2rem; }


### PR DESCRIPTION
### Motivation
- Fer que l'element `menuppal` es mostri centrat verticalment dins de `<main>` sense afectar la resta de pàgines, perquè ara altres pàgines (p. ex. `cursos`) començaven tallades a la part superior.

### Description
- Fa que la classe del `<main>` sigui configurable des de les vistes a través de `appMainClass` i conserva `app-main` com a valor per defecte en el layout (`templates/layout/default.php`).
- A la vista de pàgina (`templates/Pagines/view.php`) es detecta si el `body` conté l'element `{menuppal}` i en aquest cas s'assigna `app-main app-main--centered` per activar l'alineació centrada.
- S'ajusta el CSS de layout (`webroot/css/layout_custom.css`) perquè l'alineació per defecte del `.app-main` en desktop sigui `align-items: flex-start` i s'afegeix la regla `.app-main.app-main--centered { align-items: center; }` per al cas específic.

### Testing
- S'han executat `php -l templates/layout/default.php` i `php -l templates/Pagines/view.php` i ambdós retornen `No syntax errors detected`.
- S'ha intentat arrencar un servidor PHP intern i capturar una pantalla amb Playwright per validar visualment el canvi, però la captura no es va completar perquè el servidor local va respondre amb `ERR_EMPTY_RESPONSE`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699db979aa60832aa7ea5eed7966cdf1)