### PR TITLE
Centra títol/text de pestanya i ajusta branding de la topbar per mòbil

### DIFF
--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -373,6 +373,7 @@ body{ margin: 0; }
     transform: translateY(-50%);
 
     width: 100%;
+    display: flex;
     align-items: center;
     justify-content: center;
     text-align: center;
@@ -380,6 +381,7 @@ body{ margin: 0; }
 
   /* Centra també la fila d’icones + botó MENU */
   .app-topbar__social{
+    width: 100%;
     justify-content: center;
   }
 

--- a/webroot/css/pestanya.css
+++ b/webroot/css/pestanya.css
@@ -22,7 +22,7 @@
 
 /* Títol */
 .pestanya .titol {
-    display: inline-block;
+    display: block;
     padding: 0.75rem 1rem;
     color: white;
     font-family: 'Bebas Neue', sans-serif;
@@ -31,7 +31,7 @@
     white-space: nowrap;
     margin-bottom: 0;
     box-sizing: border-box;
-    text-align: left;
+    text-align: center;
 }
 
 /* Text */
@@ -45,7 +45,7 @@
     background-color: white;
     border-radius: 0;
     margin-top: 0;
-    text-align: left;
+    text-align: center;
 }
 
 .pestanya .text ul {
@@ -127,7 +127,15 @@
 @media (max-width: 767px) {
     .pestanya { width: 100%; }
     .pestanya .titol { font-size: 1.5rem; }
-    .pestanya .text { font-size: 1.1rem; padding: 1.2rem; }
+    .pestanya .titol,
+    .pestanya .text {
+        border: 0;
+    }
+    .pestanya .text {
+        font-size: 1.1rem;
+        padding: 0;
+        padding-left: 0.5rem;
+    }
     .pestanya .text ol li::before { font-size: 0.8rem; line-height: 1.2rem; }
 }
 


### PR DESCRIPTION
### Motivation
- Fer que les pestanyes mostrin el títol i el contingut centrats en totes les mides de pantalla i adaptar l’aspecte en dispositius mòbils segons les indicacions de disseny.
- Assegurar que en pantalles petites el logotip i els botons socials de la topbar apareguin centrats i que la pestanya no tingui vores amb el padding sol·licitat.

### Description
- Canvi a `webroot/css/pestanya.css`: ` .pestanya .titol` passa a `display: block` i `text-align: center`, i ` .pestanya .text` també queda amb `text-align: center` per centrar contingut; a més s’afegeixen regles mòbil per eliminar vores i ajustar padding a `0` amb `padding-left: 0.5rem`.
- Canvi a `webroot/css/layout_custom.css`: en l’estat mòbil la classe `.topbar-brand` s’estableix com `display: flex` i `.app-topbar__social` rep `width: 100%` per forçar el centrat horitzontal del logotip i botons socials.
- S’han commitejat els fitxers modificats amb el missatge `Ajusta el layout de pestanya i topbar en mòbil`.

### Testing
- S’ha arrencat el servidor de desenvolupament PHP amb `php -S 0.0.0.0:8080 -t webroot` i l’inici es va completar amb èxit.
- S’ha executat un script Playwright que va capturar pantalles en vista mòbil i escriptori contra `http://localhost:8080`, i va generar dues screenshots d’artifact sense errors.
- S’ha revisat el diff amb `git diff -- webroot/css/pestanya.css webroot/css/layout_custom.css` i s’ha confirmat el canvi; el `git commit` també va completar-se correctament.
- No s’han executat tests unitàris automàtics perquè els canvis només afecten fulls d’estil; totes les verificacions automatitzades relacionades amb desplegament i captures de pantalla van ser exitoses.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699de7f5d6e4832a98ed04430d73b248)