### PR TITLE
Actualitza bottombar amb contacte dinàmic i nous logos

### DIFF
--- a/templates/element/contactecentre.php
+++ b/templates/element/contactecentre.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Element: contactecentre
+ *
+ * Mostra les línies de contacte guardades a la taula configs.
+ */
+
+use Cake\ORM\TableRegistry;
+
+$Configs = TableRegistry::getTableLocator()->get('Configs');
+
+$config = $Configs->find()
+    ->select(['name', 'valuetext', 'valuelongtext'])
+    ->where([
+        'LOWER(name) IN' => ['contacte', 'contacte_centre', 'contactecentre', 'centre_contacte', 'contacte centre'],
+    ])
+    ->first();
+
+if ($config === null) {
+    $config = $Configs->find()
+        ->select(['name', 'valuetext', 'valuelongtext'])
+        ->where([
+            'OR' => [
+                'Configs.valuelongtext LIKE' => '%@%',
+                'Configs.valuetext LIKE' => '%@%',
+            ],
+        ])
+        ->orderAsc('Configs.id')
+        ->first();
+}
+
+$contactText = trim((string)($config->valuelongtext ?? $config->valuetext ?? ''));
+if ($contactText === '') {
+    $contactText = "Av. Mare de Déu de Montserrat, 78\n08024 Barcelona\ninfo@cfaguinardo.cat\n+34 934 50 48 37";
+}
+
+$lines = preg_split('/\r\n|\r|\n/', $contactText) ?: [];
+$lines = array_values(array_filter(array_map('trim', $lines), static fn(string $line): bool => $line !== ''));
+?>
+<?php foreach ($lines as $line): ?>
+    <div><?= h($line) ?></div>
+<?php endforeach; ?>

--- a/templates/element/horarisatencio.php
+++ b/templates/element/horarisatencio.php
@@ -148,7 +148,7 @@ foreach ($itemsByDate as $k => $info) {
 }
 
 ?>
-<table style="border-collapse:collapse; width:auto;">
+<table class="horarisatencio-table" style="border-collapse:collapse; width:auto;">
     <tbody>
         <?php
         $prevDate = null;
@@ -171,11 +171,11 @@ foreach ($itemsByDate as $k => $info) {
             // Si no hi ha franges aplicables: dia laborable tancat
             $timesText = !empty($times) ? implode(' i ', $times) : __('Tancat');
 
-            $tdBase = 'padding:4px 0; border:none; vertical-align:top;';
-            $sepStyle = $isWeekSeparator ? 'border-top:1px solid rgba(0,0,0,0.2); padding-top:8px;' : '';
+            $tdBase = 'padding:2px 0; border:none; vertical-align:top;';
+            $sepStyle = $isWeekSeparator ? 'border-top:1px solid rgba(0,0,0,0.2); padding-top:5px;' : '';
         ?>
             <tr>
-                <td style="<?= $tdBase ?> text-align:right; font-weight:700; padding-right:12px; <?= $sepStyle ?>">
+                <td style="<?= $tdBase ?> text-align:right; font-weight:700; padding-right:8px; <?= $sepStyle ?>">
                     <?= h($dayLabel) ?>
                 </td>
                 <td style="<?= $tdBase ?> text-align:left; <?= $sepStyle ?>">

--- a/templates/element/horarisatencio.php
+++ b/templates/element/horarisatencio.php
@@ -169,7 +169,7 @@ foreach ($itemsByDate as $k => $info) {
             $times = $info['hasSpecial'] ? $info['specialTimes'] : $info['regularTimes'];
 
             // Si no hi ha franges aplicables: dia laborable tancat
-            $timesText = !empty($times) ? implode(' i ', $times) : __('Tancat');
+            $timesText = !empty($times) ? implode("\n", $times) : __('Tancat');
 
             $tdBase = 'padding:2px 0; border:none; vertical-align:top;';
             $sepStyle = $isWeekSeparator ? 'border-top:1px solid rgba(0,0,0,0.2); padding-top:5px;' : '';
@@ -179,7 +179,7 @@ foreach ($itemsByDate as $k => $info) {
                     <?= h($dayLabel) ?>
                 </td>
                 <td style="<?= $tdBase ?> text-align:left; <?= $sepStyle ?>">
-                    <?= h($timesText) ?>
+                    <?= nl2br(h($timesText)) ?>
                 </td>
             </tr>
         <?php

--- a/templates/layout/default.php
+++ b/templates/layout/default.php
@@ -187,22 +187,28 @@ $pageLevel = function (string $orderCode): int {
 <!-- BOTTOMBAR -->
 <footer class="app-bottombar">
     <div class="app-bottombar__inner">
-        <section class="app-bottombar__col">
-            <div class="bottombar-title">GENERALITAT DE CATALUNYA</div>
-            <div class="bottombar-text">
-                Text Generalitat...
+        <section class="app-bottombar__col app-bottombar__col--left">
+            <div class="bottombar-logos">
+                <?= $this->Html->image('line_small.png', [
+                    'alt' => 'Línia corporativa',
+                    'class' => 'bottombar-logos__line'
+                ]) ?>
+                <?= $this->Html->image('consorci.jpg', [
+                    'alt' => 'Consorci d’Educació de Barcelona',
+                    'class' => 'bottombar-logos__consorci'
+                ]) ?>
             </div>
         </section>
 
         <section class="app-bottombar__col">
             <div class="bottombar-title">CONTACTE</div>
             <div class="bottombar-text">
-                Text contacte...
+                <?= $this->element('contactecentre') ?>
             </div>
         </section>
 
-        <section class="app-bottombar__col">
-            <div class="bottombar-title">HORARIS D’ATENCIÓ</div>
+        <section class="app-bottombar__col app-bottombar__col--right">
+            <div class="bottombar-title">HORARI D’ATENCIÓ</div>
             <div class="bottombar-text">
                 <?= $this->element('horarisatencio') ?>
             </div>

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -4,7 +4,7 @@
 
   /* DESKTOP (10/80/10) */
   --topbar-h-desktop: 10vh;
-  --bottombar-h-desktop: 20vh;
+  --bottombar-h-desktop: 24vh;
 
   --sidebar-w: 280px;
   --pink: #e83e8c;
@@ -220,6 +220,16 @@ body{ margin: 0; }
   text-align: right;
 }
 
+.app-bottombar__col--right .bottombar-text{
+  display: flex;
+  justify-content: flex-end;
+}
+
+.horarisatencio-table{
+  margin-left: auto;
+}
+
+
 /* =========================
    DESKTOP (>=901px)
    Sidebar 100vh + dreta en 10/80/10 (fixes)
@@ -366,10 +376,11 @@ body{ margin: 0; }
 ========================= */
 @media (max-width: 900px){
 
-  /* Evita que el scroll sigui del body (així la topbar no "balla") */
+  /* En mòbil el scroll és de pàgina perquè la bottombar quedi després del main */
   html, body{
-    height: 100%;
-    overflow: hidden;
+    height: auto;
+    overflow-x: hidden;
+    overflow-y: auto;
   }
 
   /* TOPBAR fixa */
@@ -424,19 +435,13 @@ body{ margin: 0; }
     --logo-offset-x: 0rem;
   }
 
-  /* MAIN: ocupa la pantalla sota la topbar i fa scroll */
+  /* MAIN en flux normal, sota topbar fixa */
   .app-main{
-    position: fixed;
-    top: var(--topbar-h-mobile);
-    left: 0;
-    right: 0;
-    bottom: 0;
-
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
-
-    margin: 0;
+    position: static;
+    margin-top: var(--topbar-h-mobile);
     padding: 0;
+    overflow: visible;
+    min-height: 0;
   }
 
   /* Marges laterals del contingut */
@@ -510,5 +515,23 @@ body{ margin: 0; }
   .app-bottombar__inner{
     display: block;
     padding: 12px;
+  }
+
+  .app-bottombar__inner > section:nth-child(1){
+    text-align: left;
+  }
+
+  .app-bottombar__inner > section:nth-child(2),
+  .app-bottombar__inner > section:nth-child(3){
+    text-align: center;
+  }
+
+  .app-bottombar__col--right .bottombar-text{
+    justify-content: center;
+  }
+
+  .horarisatencio-table{
+    margin-left: auto;
+    margin-right: auto;
   }
 }

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -176,14 +176,48 @@ body{ margin: 0; }
 /* Textos bottombar */
 .bottombar-title{
   font-family: "Bebas Neue", Bebas, Arial, sans-serif;
-  font-size: 1.2rem;
+  color: var(--pink);
+  font-size: 1.5rem;
   letter-spacing: .02em;
+  margin-bottom: 0.6rem;
 }
 
 .bottombar-text{
-  margin-top: 6px;
+  margin-top: 0;
   font-size: .95rem;
   line-height: 1.25rem;
+}
+
+.bottombar-logos{
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.8rem;
+}
+
+.bottombar-logos__line{
+  max-width: 170px;
+  width: 100%;
+  height: auto;
+}
+
+.bottombar-logos__consorci{
+  max-width: 210px;
+  width: 100%;
+  height: auto;
+}
+
+
+.app-bottombar__col--left{
+  text-align: left;
+}
+
+.app-bottombar__col:nth-child(2){
+  text-align: center;
+}
+
+.app-bottombar__col--right{
+  text-align: right;
 }
 
 /* =========================

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -179,6 +179,7 @@ body{ margin: 0; }
   color: var(--pink);
   font-size: 1.5rem;
   letter-spacing: .02em;
+  margin-top: 0.45rem;
   margin-bottom: 0.6rem;
 }
 
@@ -518,7 +519,11 @@ body{ margin: 0; }
   }
 
   .app-bottombar__inner > section:nth-child(1){
-    text-align: left;
+    text-align: center;
+  }
+
+  .app-bottombar__inner > section:nth-child(1) .bottombar-logos{
+    align-items: center;
   }
 
   .app-bottombar__inner > section:nth-child(2),


### PR DESCRIPTION
### Motivation
- Fer visible el contacte del centre a la bottombar llegint les dades des de la taula `configs` i mostrar un fallback amb les línies facilitades.
- Col·locar a la primera columna els logos `webroot/img/line_small.png` i `webroot/img/consorci.jpg` alineats a l'esquerra i alinear la tercera columna d'`HORARI D’ATENCIÓ` a la dreta.
- Uniformitzar l'estil dels títols de la bottombar (rosa corporatiu, mida més gran i més marge) i ajustar mides/espaiats dels logos.

### Description
- S'actualitza `templates/layout/default.php` per substituir la primera columna per un bloc de logos, mostrar l'element nou `contactecentre` sota el títol `CONTACTE`, i fer que la columna d'horaris vagi amb la classe `app-bottombar__col--right` perquè s'alineï a la dreta.
- S'afegeix l'element `templates/element/contactecentre.php` que llegeix la configuració des de la taula `Configs` (prioritza noms habituals de configuració), fa un fallback amb una cerca d'entrades que continguin una arrova (`@`) i, si no hi ha resultat, utilitza el text per defecte proporcionat; el text es separa per línies i s'imprimeix cada línia en un `div`.
- S'actualitza `webroot/css/layout_custom.css` per posar els títols de la bottombar en `var(--pink)` amb mida augmentada i marge inferior, ajustar l'espaiat del text, i afegir classes per al layout i les mides dels logos (`.bottombar-logos`, `.bottombar-logos__line`, `.bottombar-logos__consorci`) així com classes d'alineació per les columnes (`.app-bottombar__col--left`, `.app-bottombar__col--right`).

### Testing
- S'ha validat la sintaxi PHP amb `php -l templates/layout/default.php` i `php -l templates/element/contactecentre.php`, amb èxit (no s'han detectat errors de sintaxi).
- S'ha intentat arrencar el servidor de desenvolupament i capturar la pàgina amb Playwright per verificar visualment la bottombar, però la càrrega completa de la pàgina ha fallat per una incompatibilitat de `cakephp/chronos` amb la versió de PHP en l'entorn (error 500), de manera que la comprovació visual no ha pogut completar-se tot i que s'ha generat un intent de captura.
- Les comprovacions automàtiques realitzades (sintaxi i generació d'artifact de captura) són les que es poden executar en l'entorn actual; la visualització final a navegador es recomana provar en entorn amb dependències PHP/CakePHP compatibles per confirmar render i posicionament definitiu.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a064b49b68832a9fb9a2f29c1ec5e5)