### PR TITLE
Add dynamic Pagines placeholders for Configs/Years values

### DIFF
--- a/templates/Pagines/add.php
+++ b/templates/Pagines/add.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+?>
+
+<div class="pagines form content">
+    <h3><?= __('Ajuda per a elements dinàmics') ?></h3>
+    <p><?= __('Pots fer servir aquests noms entre claus dins del cos de la pàgina:') ?></p>
+    <ul>
+        <li><code>{telefon}</code>: <?= __('valor de Configs.valuetext on name = telefoncentre') ?></li>
+        <li><code>{email}</code>: <?= __('valor de Configs.valuetext on name = mailcentre') ?></li>
+        <li><code>{contactevcf}</code>: <?= __('valor de Configs.valuetext on name = urlcontactevcf') ?></li>
+        <li><code>{data_inici_preinscripcio}</code>: <?= __('data més gran del camp Years.datainicipreinscripcio (format català)') ?></li>
+        <li><code>{data_fi_preinscripcio}</code>: <?= __('data més gran del camp Years.datafipreinscripcio (format català)') ?></li>
+        <li><code>{data_inici_reclamacions}</code>: <?= __('data més gran del camp Years.datainicireclamacions (format català)') ?></li>
+        <li><code>{data_fi_reclamacions}</code>: <?= __('data més gran del camp Years.datafireclamacions (format català)') ?></li>
+        <li><code>{data_llista_admesos}</code>: <?= __('data més gran del camp Years.datallistaadmesos (format català)') ?></li>
+        <li><code>{data_inici_matricula}</code>: <?= __('data més gran del camp Years.datainicimatricula (format català)') ?></li>
+        <li><code>{data_fi_matricula}</code>: <?= __('data més gran del camp Years.datafimatricula (format català)') ?></li>
+        <li><code>{periode_preinscripcio}</code>: <?= __('text "del ... al ..." amb les dates màximes de datainicipreinscripcio i datafipreinscripcio') ?></li>
+        <li><code>{periode_reclamacions}</code>: <?= __('text "del ... al ..." amb les dates màximes de datainicireclamacions i datafireclamacions') ?></li>
+        <li><code>{periode_matricula}</code>: <?= __('text "del ... al ..." amb les dates màximes de datainicimatricula i datafimatricula') ?></li>
+        <li><code>{dies_caducitat_llista_espera}</code>: <?= __('valor del camp Years.diescaducitatllistaespera del registre més recent') ?></li>
+        <li><code>{dies_no_justificades}</code>: <?= __('valor del camp Years.diesnojustificades del registre més recent') ?></li>
+    </ul>
+</div>

--- a/templates/Pagines/edit.php
+++ b/templates/Pagines/edit.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+?>
+
+<div class="pagines form content">
+    <h3><?= __('Ajuda per a elements dinàmics') ?></h3>
+    <p><?= __('Pots fer servir aquests noms entre claus dins del cos de la pàgina:') ?></p>
+    <ul>
+        <li><code>{telefon}</code>: <?= __('valor de Configs.valuetext on name = telefoncentre') ?></li>
+        <li><code>{email}</code>: <?= __('valor de Configs.valuetext on name = mailcentre') ?></li>
+        <li><code>{contactevcf}</code>: <?= __('valor de Configs.valuetext on name = urlcontactevcf') ?></li>
+        <li><code>{data_inici_preinscripcio}</code>: <?= __('data més gran del camp Years.datainicipreinscripcio (format català)') ?></li>
+        <li><code>{data_fi_preinscripcio}</code>: <?= __('data més gran del camp Years.datafipreinscripcio (format català)') ?></li>
+        <li><code>{data_inici_reclamacions}</code>: <?= __('data més gran del camp Years.datainicireclamacions (format català)') ?></li>
+        <li><code>{data_fi_reclamacions}</code>: <?= __('data més gran del camp Years.datafireclamacions (format català)') ?></li>
+        <li><code>{data_llista_admesos}</code>: <?= __('data més gran del camp Years.datallistaadmesos (format català)') ?></li>
+        <li><code>{data_inici_matricula}</code>: <?= __('data més gran del camp Years.datainicimatricula (format català)') ?></li>
+        <li><code>{data_fi_matricula}</code>: <?= __('data més gran del camp Years.datafimatricula (format català)') ?></li>
+        <li><code>{periode_preinscripcio}</code>: <?= __('text "del ... al ..." amb les dates màximes de datainicipreinscripcio i datafipreinscripcio') ?></li>
+        <li><code>{periode_reclamacions}</code>: <?= __('text "del ... al ..." amb les dates màximes de datainicireclamacions i datafireclamacions') ?></li>
+        <li><code>{periode_matricula}</code>: <?= __('text "del ... al ..." amb les dates màximes de datainicimatricula i datafimatricula') ?></li>
+        <li><code>{dies_caducitat_llista_espera}</code>: <?= __('valor del camp Years.diescaducitatllistaespera del registre més recent') ?></li>
+        <li><code>{dies_no_justificades}</code>: <?= __('valor del camp Years.diesnojustificades del registre més recent') ?></li>
+    </ul>
+</div>

--- a/templates/element/_pagines_dynamic_utils.php
+++ b/templates/element/_pagines_dynamic_utils.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+use Cake\ORM\TableRegistry;
+
+if (!function_exists('paginesGetConfigValue')) {
+    function paginesGetConfigValue(string $configName): string
+    {
+        $configsTable = TableRegistry::getTableLocator()->get('Configs');
+        $config = $configsTable->find()
+            ->select(['valuetext'])
+            ->where(['name' => $configName])
+            ->first();
+
+        return trim((string)($config->valuetext ?? ''));
+    }
+}
+
+if (!function_exists('paginesGetYearMaxDate')) {
+    function paginesGetYearMaxDate(string $field): ?\DateTimeInterface
+    {
+        $yearsTable = TableRegistry::getTableLocator()->get('Years');
+        $year = $yearsTable->find()
+            ->select([$field])
+            ->where(["{$field} IS NOT" => null])
+            ->order([$field => 'DESC'])
+            ->first();
+
+        $date = $year?->{$field};
+        return $date instanceof \DateTimeInterface ? $date : null;
+    }
+}
+
+if (!function_exists('paginesGetLatestYearFieldValue')) {
+    function paginesGetLatestYearFieldValue(string $field): string
+    {
+        $yearsTable = TableRegistry::getTableLocator()->get('Years');
+        $year = $yearsTable->find()
+            ->select([$field])
+            ->where(["{$field} IS NOT" => null])
+            ->order(['id' => 'DESC'])
+            ->first();
+
+        return trim((string)($year?->{$field} ?? ''));
+    }
+}
+
+if (!function_exists('paginesFormatCatalanDate')) {
+    function paginesFormatCatalanDate(?\DateTimeInterface $date): string
+    {
+        if (!$date) {
+            return '';
+        }
+
+        $weekDays = [
+            0 => 'diumenge',
+            1 => 'dilluns',
+            2 => 'dimarts',
+            3 => 'dimecres',
+            4 => 'dijous',
+            5 => 'divendres',
+            6 => 'dissabte',
+        ];
+
+        $months = [
+            1 => 'gener',
+            2 => 'febrer',
+            3 => 'març',
+            4 => 'abril',
+            5 => 'maig',
+            6 => 'juny',
+            7 => 'juliol',
+            8 => 'agost',
+            9 => 'setembre',
+            10 => 'octubre',
+            11 => 'novembre',
+            12 => 'desembre',
+        ];
+
+        $weekday = $weekDays[(int)$date->format('w')] ?? '';
+        $day = (int)$date->format('j');
+        $month = $months[(int)$date->format('n')] ?? '';
+
+        return trim(sprintf('%s %d de %s', $weekday, $day, $month));
+    }
+}

--- a/templates/element/contactevcf.php
+++ b/templates/element/contactevcf.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesGetConfigValue('urlcontactevcf'));

--- a/templates/element/data_fi_matricula.php
+++ b/templates/element/data_fi_matricula.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesFormatCatalanDate(paginesGetYearMaxDate('datafimatricula')));

--- a/templates/element/data_fi_preinscripcio.php
+++ b/templates/element/data_fi_preinscripcio.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesFormatCatalanDate(paginesGetYearMaxDate('datafipreinscripcio')));

--- a/templates/element/data_fi_reclamacions.php
+++ b/templates/element/data_fi_reclamacions.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesFormatCatalanDate(paginesGetYearMaxDate('datafireclamacions')));

--- a/templates/element/data_inici_matricula.php
+++ b/templates/element/data_inici_matricula.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesFormatCatalanDate(paginesGetYearMaxDate('datainicimatricula')));

--- a/templates/element/data_inici_preinscripcio.php
+++ b/templates/element/data_inici_preinscripcio.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesFormatCatalanDate(paginesGetYearMaxDate('datainicipreinscripcio')));

--- a/templates/element/data_inici_reclamacions.php
+++ b/templates/element/data_inici_reclamacions.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesFormatCatalanDate(paginesGetYearMaxDate('datainicireclamacions')));

--- a/templates/element/data_llista_admesos.php
+++ b/templates/element/data_llista_admesos.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesFormatCatalanDate(paginesGetYearMaxDate('datallistaadmesos')));

--- a/templates/element/dies_caducitat_llista_espera.php
+++ b/templates/element/dies_caducitat_llista_espera.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesGetLatestYearFieldValue('diescaducitatllistaespera'));

--- a/templates/element/dies_no_justificades.php
+++ b/templates/element/dies_no_justificades.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesGetLatestYearFieldValue('diesnojustificades'));

--- a/templates/element/email.php
+++ b/templates/element/email.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesGetConfigValue('mailcentre'));

--- a/templates/element/periode_matricula.php
+++ b/templates/element/periode_matricula.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+$inici = paginesGetYearMaxDate('datainicimatricula');
+$fi = paginesGetYearMaxDate('datafimatricula');
+
+if (!$inici || !$fi) {
+    return;
+}
+
+echo h(sprintf('del %s al %s', paginesFormatCatalanDate($inici), paginesFormatCatalanDate($fi)));

--- a/templates/element/periode_preinscripcio.php
+++ b/templates/element/periode_preinscripcio.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+$inici = paginesGetYearMaxDate('datainicipreinscripcio');
+$fi = paginesGetYearMaxDate('datafipreinscripcio');
+
+if (!$inici || !$fi) {
+    return;
+}
+
+echo h(sprintf('del %s al %s', paginesFormatCatalanDate($inici), paginesFormatCatalanDate($fi)));

--- a/templates/element/periode_reclamacions.php
+++ b/templates/element/periode_reclamacions.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+$inici = paginesGetYearMaxDate('datainicireclamacions');
+$fi = paginesGetYearMaxDate('datafireclamacions');
+
+if (!$inici || !$fi) {
+    return;
+}
+
+echo h(sprintf('del %s al %s', paginesFormatCatalanDate($inici), paginesFormatCatalanDate($fi)));

--- a/templates/element/telefon.php
+++ b/templates/element/telefon.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesGetConfigValue('telefoncentre'));


### PR DESCRIPTION
### Motivation

- Allow content authors to embed site `configs` and `years` data directly inside page bodies using readable placeholders like `{data_inici_preinscripcio}`. 
- Centralize DB access and date formatting to avoid duplicating logic across multiple elements. 
- Provide inline help in the page admin so authors know which placeholders are available and what they return.

### Description

- Added a shared helper `templates/element/_pagines_dynamic_utils.php` with `paginesGetConfigValue`, `paginesGetYearMaxDate`, `paginesGetLatestYearFieldValue` and `paginesFormatCatalanDate` to read DB values and format dates as Catalan strings (e.g. "dimarts 4 de juny").
- Added element templates that return `Configs.valuetext` values: `templates/element/telefon.php`, `templates/element/email.php`, and `templates/element/contactevcf.php` (use `paginesGetConfigValue`).
- Added date elements that return the maximum date for `years` fields formatted in Catalan: `data_inici_preinscripcio`, `data_fi_preinscripcio`, `data_inici_reclamacions`, `data_fi_reclamacions`, `data_llista_admesos`, `data_inici_matricula`, and `data_fi_matricula` under `templates/element/` (they use `paginesGetYearMaxDate` + `paginesFormatCatalanDate`).
- Added period elements that render expressions like `del dimarts 4 de juny al dijous 6 de juny`: `periode_preinscripcio`, `periode_reclamacions`, and `periode_matricula` (they combine two `paginesGetYearMaxDate` calls).
- Added numeric/year-derived elements `dies_caducitat_llista_espera` and `dies_no_justificades` that return the latest `Years` record values using `paginesGetLatestYearFieldValue`.
- Added admin help templates `templates/Pagines/add.php` and `templates/Pagines/edit.php` documenting all supported placeholders and their return values.

### Testing

- Ran PHP syntax checks (`php -l`) across all new templates and helper file and they reported `No syntax errors detected` for every added file. 
- Attempted an automated Playwright screenshot of the local app, which failed with `ERR_EMPTY_RESPONSE` because there was no web server listening on the test port. 
- All added files were committed and are present in the branch for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a17984d5d4832abed87894569ad985)