### PR TITLE
Add dynamic Pagines elements and utilities (Catalan dates & preinscripcio schedule)

### DIFF
--- a/templates/Pagines/add.php
+++ b/templates/Pagines/add.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+?>
+
+<div class="pagines form content">
+    <h3><?= __('Ajuda per a elements dinàmics') ?></h3>
+    <p><?= __('Pots fer servir aquests noms entre claus dins del cos de la pàgina:') ?></p>
+    <ul>
+        <li><code>{telefon}</code>: <?= __('valor de Configs.valuetext on name = telefoncentre') ?></li>
+        <li><code>{email}</code>: <?= __('valor de Configs.valuetext on name = mailcentre') ?></li>
+        <li><code>{contactevcf}</code>: <?= __('valor de Configs.valuetext on name = urlcontactevcf') ?></li>
+        <li><code>{data_inici_preinscripcio}</code>: <?= __('data més gran del camp Years.datainicipreinscripcio (format català)') ?></li>
+        <li><code>{data_fi_preinscripcio}</code>: <?= __('data més gran del camp Years.datafipreinscripcio (format català)') ?></li>
+        <li><code>{data_inici_reclamacions}</code>: <?= __('data més gran del camp Years.datainicireclamacions (format català)') ?></li>
+        <li><code>{data_fi_reclamacions}</code>: <?= __('data més gran del camp Years.datafireclamacions (format català)') ?></li>
+        <li><code>{data_llista_admesos}</code>: <?= __('data més gran del camp Years.datallistaadmesos (format català)') ?></li>
+        <li><code>{data_inici_matricula}</code>: <?= __('data més gran del camp Years.datainicimatricula (format català)') ?></li>
+        <li><code>{data_fi_matricula}</code>: <?= __('data més gran del camp Years.datafimatricula (format català)') ?></li>
+        <li><code>{periode_preinscripcio}</code>: <?= __('text "del ... al ..." amb les dates màximes de datainicipreinscripcio i datafipreinscripcio') ?></li>
+        <li><code>{periode_reclamacions}</code>: <?= __('text "del ... al ..." amb les dates màximes de datainicireclamacions i datafireclamacions') ?></li>
+        <li><code>{periode_matricula}</code>: <?= __('text "del ... al ..." amb les dates màximes de datainicimatricula i datafimatricula') ?></li>
+        <li><code>{dies_caducitat_llista_espera}</code>: <?= __('valor del camp Years.diescaducitatllistaespera del registre més recent') ?></li>
+        <li><code>{dies_no_justificades}</code>: <?= __('valor del camp Years.diesnojustificades del registre més recent') ?></li>
+        <li><code>{horaripreinscripcio}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicipreinscripcio i la data màxima de datafipreinscripcio, ambdós inclosos') ?></li>
+    </ul>
+</div>

--- a/templates/Pagines/edit.php
+++ b/templates/Pagines/edit.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+?>
+
+<div class="pagines form content">
+    <h3><?= __('Ajuda per a elements dinàmics') ?></h3>
+    <p><?= __('Pots fer servir aquests noms entre claus dins del cos de la pàgina:') ?></p>
+    <ul>
+        <li><code>{telefon}</code>: <?= __('valor de Configs.valuetext on name = telefoncentre') ?></li>
+        <li><code>{email}</code>: <?= __('valor de Configs.valuetext on name = mailcentre') ?></li>
+        <li><code>{contactevcf}</code>: <?= __('valor de Configs.valuetext on name = urlcontactevcf') ?></li>
+        <li><code>{data_inici_preinscripcio}</code>: <?= __('data més gran del camp Years.datainicipreinscripcio (format català)') ?></li>
+        <li><code>{data_fi_preinscripcio}</code>: <?= __('data més gran del camp Years.datafipreinscripcio (format català)') ?></li>
+        <li><code>{data_inici_reclamacions}</code>: <?= __('data més gran del camp Years.datainicireclamacions (format català)') ?></li>
+        <li><code>{data_fi_reclamacions}</code>: <?= __('data més gran del camp Years.datafireclamacions (format català)') ?></li>
+        <li><code>{data_llista_admesos}</code>: <?= __('data més gran del camp Years.datallistaadmesos (format català)') ?></li>
+        <li><code>{data_inici_matricula}</code>: <?= __('data més gran del camp Years.datainicimatricula (format català)') ?></li>
+        <li><code>{data_fi_matricula}</code>: <?= __('data més gran del camp Years.datafimatricula (format català)') ?></li>
+        <li><code>{periode_preinscripcio}</code>: <?= __('text "del ... al ..." amb les dates màximes de datainicipreinscripcio i datafipreinscripcio') ?></li>
+        <li><code>{periode_reclamacions}</code>: <?= __('text "del ... al ..." amb les dates màximes de datainicireclamacions i datafireclamacions') ?></li>
+        <li><code>{periode_matricula}</code>: <?= __('text "del ... al ..." amb les dates màximes de datainicimatricula i datafimatricula') ?></li>
+        <li><code>{dies_caducitat_llista_espera}</code>: <?= __('valor del camp Years.diescaducitatllistaespera del registre més recent') ?></li>
+        <li><code>{dies_no_justificades}</code>: <?= __('valor del camp Years.diesnojustificades del registre més recent') ?></li>
+        <li><code>{horaripreinscripcio}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicipreinscripcio i la data màxima de datafipreinscripcio, ambdós inclosos') ?></li>
+    </ul>
+</div>

--- a/templates/element/_pagines_dynamic_utils.php
+++ b/templates/element/_pagines_dynamic_utils.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+use Cake\ORM\TableRegistry;
+
+if (!function_exists('paginesGetConfigValue')) {
+    function paginesGetConfigValue(string $configName): string
+    {
+        $configsTable = TableRegistry::getTableLocator()->get('Configs');
+        $config = $configsTable->find()
+            ->select(['valuetext'])
+            ->where(['name' => $configName])
+            ->first();
+
+        return trim((string)($config->valuetext ?? ''));
+    }
+}
+
+if (!function_exists('paginesGetYearMaxDate')) {
+    function paginesGetYearMaxDate(string $field): ?\DateTimeInterface
+    {
+        $yearsTable = TableRegistry::getTableLocator()->get('Years');
+        $year = $yearsTable->find()
+            ->select([$field])
+            ->where(["{$field} IS NOT" => null])
+            ->order([$field => 'DESC'])
+            ->first();
+
+        $date = $year?->{$field};
+        return $date instanceof \DateTimeInterface ? $date : null;
+    }
+}
+
+if (!function_exists('paginesGetLatestYearFieldValue')) {
+    function paginesGetLatestYearFieldValue(string $field): string
+    {
+        $yearsTable = TableRegistry::getTableLocator()->get('Years');
+        $year = $yearsTable->find()
+            ->select([$field])
+            ->where(["{$field} IS NOT" => null])
+            ->order(['id' => 'DESC'])
+            ->first();
+
+        return trim((string)($year?->{$field} ?? ''));
+    }
+}
+
+if (!function_exists('paginesFormatCatalanDate')) {
+    function paginesFormatCatalanDate(?\DateTimeInterface $date): string
+    {
+        if (!$date) {
+            return '';
+        }
+
+        $weekDays = [
+            0 => 'diumenge',
+            1 => 'dilluns',
+            2 => 'dimarts',
+            3 => 'dimecres',
+            4 => 'dijous',
+            5 => 'divendres',
+            6 => 'dissabte',
+        ];
+
+        $months = [
+            1 => 'gener',
+            2 => 'febrer',
+            3 => 'març',
+            4 => 'abril',
+            5 => 'maig',
+            6 => 'juny',
+            7 => 'juliol',
+            8 => 'agost',
+            9 => 'setembre',
+            10 => 'octubre',
+            11 => 'novembre',
+            12 => 'desembre',
+        ];
+
+        $weekday = $weekDays[(int)$date->format('w')] ?? '';
+        $day = (int)$date->format('j');
+        $month = $months[(int)$date->format('n')] ?? '';
+
+        return trim(sprintf('%s %d de %s', $weekday, $day, $month));
+    }
+}

--- a/templates/element/contactevcf.php
+++ b/templates/element/contactevcf.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesGetConfigValue('urlcontactevcf'));

--- a/templates/element/data_fi_matricula.php
+++ b/templates/element/data_fi_matricula.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesFormatCatalanDate(paginesGetYearMaxDate('datafimatricula')));

--- a/templates/element/data_fi_preinscripcio.php
+++ b/templates/element/data_fi_preinscripcio.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesFormatCatalanDate(paginesGetYearMaxDate('datafipreinscripcio')));

--- a/templates/element/data_fi_reclamacions.php
+++ b/templates/element/data_fi_reclamacions.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesFormatCatalanDate(paginesGetYearMaxDate('datafireclamacions')));

--- a/templates/element/data_inici_matricula.php
+++ b/templates/element/data_inici_matricula.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesFormatCatalanDate(paginesGetYearMaxDate('datainicimatricula')));

--- a/templates/element/data_inici_preinscripcio.php
+++ b/templates/element/data_inici_preinscripcio.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesFormatCatalanDate(paginesGetYearMaxDate('datainicipreinscripcio')));

--- a/templates/element/data_inici_reclamacions.php
+++ b/templates/element/data_inici_reclamacions.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesFormatCatalanDate(paginesGetYearMaxDate('datainicireclamacions')));

--- a/templates/element/data_llista_admesos.php
+++ b/templates/element/data_llista_admesos.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesFormatCatalanDate(paginesGetYearMaxDate('datallistaadmesos')));

--- a/templates/element/dies_caducitat_llista_espera.php
+++ b/templates/element/dies_caducitat_llista_espera.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesGetLatestYearFieldValue('diescaducitatllistaespera'));

--- a/templates/element/dies_no_justificades.php
+++ b/templates/element/dies_no_justificades.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesGetLatestYearFieldValue('diesnojustificades'));

--- a/templates/element/email.php
+++ b/templates/element/email.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesGetConfigValue('mailcentre'));

--- a/templates/element/horaripreinscripcio.php
+++ b/templates/element/horaripreinscripcio.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Element: horaripreinscripcio
+ *
+ * Igual que l'element horarisatencio, però el rang de dies és
+ * [datainicipreinscripcio .. datafipreinscripcio] (ambdós inclosos),
+ * prenent la data màxima de cada camp a Years.
+ */
+
+declare(strict_types=1);
+
+use Cake\ORM\TableRegistry;
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+$daysCa = [
+    1 => 'dilluns',
+    2 => 'dimarts',
+    3 => 'dimecres',
+    4 => 'dijous',
+    5 => 'divendres',
+    6 => 'dissabte',
+    7 => 'diumenge',
+];
+
+$start = paginesGetYearMaxDate('datainicipreinscripcio');
+$end = paginesGetYearMaxDate('datafipreinscripcio');
+
+if (!$start || !$end || $start > $end) {
+    return;
+}
+
+// Com a horarisatencio: només dies laborables.
+$dates = [];
+for ($d = $start; $d <= $end; $d = $d->modify('+1 day')) {
+    $dow = (int)$d->format('N');
+    if ($dow === 6 || $dow === 7) {
+        continue;
+    }
+
+    $date = \Cake\I18n\FrozenDate::parseDate($d->format('Y-m-d'));
+    if ($date) {
+        $dates[] = $date;
+    }
+}
+
+if (empty($dates)) {
+    return;
+}
+
+$weekdaysInRange = array_values(array_unique(array_map(fn($x) => (int)$x->format('N'), $dates)));
+
+$Horaris = TableRegistry::getTableLocator()->get('Horarisatencio');
+
+$rows = $Horaris->find()
+    ->contain(['Days'])
+    ->where([
+        'OR' => [
+            [
+                'Horarisatencio.specialdate >=' => $start,
+                'Horarisatencio.specialdate <=' => $end,
+            ],
+            [
+                'Horarisatencio.specialdate IS' => null,
+                'Horarisatencio.day_id IN' => $weekdaysInRange,
+            ],
+        ],
+    ])
+    ->order([
+        'Horarisatencio.specialdate' => 'ASC',
+        'Horarisatencio.day_id' => 'ASC',
+        'Horarisatencio.horainici' => 'ASC',
+        'Horarisatencio.horafinal' => 'ASC',
+    ])
+    ->all();
+
+$itemsByDate = [];
+foreach ($dates as $d) {
+    $k = $d->format('Y-m-d');
+    $itemsByDate[$k] = [
+        'date' => $d,
+        'hasSpecial' => false,
+        'specialTimes' => [],
+        'regularTimes' => [],
+    ];
+}
+
+$fmtTime = function ($t): string {
+    if (empty($t)) {
+        return '';
+    }
+    try {
+        return $t->i18nFormat('HH:mm');
+    } catch (\Throwable $e) {
+        return substr((string)$t, 0, 5);
+    }
+};
+
+foreach ($rows as $r) {
+    if (empty($r->specialdate)) {
+        continue;
+    }
+
+    $k = $r->specialdate->format('Y-m-d');
+    if (!isset($itemsByDate[$k])) {
+        continue;
+    }
+
+    $slot = trim($fmtTime($r->horainici) . '-' . $fmtTime($r->horafinal), '-');
+    if ($slot !== '' && $slot !== '-') {
+        $itemsByDate[$k]['specialTimes'][] = $slot;
+    }
+    $itemsByDate[$k]['hasSpecial'] = true;
+}
+
+foreach ($rows as $r) {
+    if (!empty($r->specialdate)) {
+        continue;
+    }
+
+    $dayId = (int)($r->day_id ?? 0);
+    if ($dayId < 1 || $dayId > 7) {
+        continue;
+    }
+
+    $slot = trim($fmtTime($r->horainici) . '-' . $fmtTime($r->horafinal), '-');
+    if ($slot === '' || $slot === '-') {
+        continue;
+    }
+
+    foreach ($dates as $d) {
+        if ((int)$d->format('N') !== $dayId) {
+            continue;
+        }
+
+        $k = $d->format('Y-m-d');
+        if (!isset($itemsByDate[$k])) {
+            continue;
+        }
+        if ($itemsByDate[$k]['hasSpecial']) {
+            continue;
+        }
+
+        $itemsByDate[$k]['regularTimes'][] = $slot;
+    }
+}
+
+foreach ($itemsByDate as $k => $info) {
+    $special = array_values(array_unique(array_filter($info['specialTimes'], fn($t) => $t !== '' && $t !== '-')));
+    $regular = array_values(array_unique(array_filter($info['regularTimes'], fn($t) => $t !== '' && $t !== '-')));
+
+    sort($special, SORT_NATURAL);
+    sort($regular, SORT_NATURAL);
+
+    $itemsByDate[$k]['specialTimes'] = $special;
+    $itemsByDate[$k]['regularTimes'] = $regular;
+}
+?>
+<table class="horarisatencio-table" style="border-collapse:collapse; width:auto;">
+    <tbody>
+        <?php
+        $prevDate = null;
+
+        foreach ($itemsByDate as $k => $info):
+            $d = $info['date'];
+            $dow = (int)$d->format('N');
+
+            $isWeekSeparator = ($dow === 1 && $prevDate !== null);
+
+            $dayName = $daysCa[$dow] ?? strtolower($d->i18nFormat('EEEE'));
+            $asterisk = $info['hasSpecial'] ? '*' : '';
+            $dayLabel = $dayName . $asterisk . ' ' . $d->format('j');
+
+            $times = $info['hasSpecial'] ? $info['specialTimes'] : $info['regularTimes'];
+            $timesText = !empty($times) ? implode("\n", $times) : __('Tancat');
+
+            $tdBase = 'padding:2px 0; border:none; vertical-align:top;';
+            $sepStyle = $isWeekSeparator ? 'border-top:1px solid rgba(0,0,0,0.2); padding-top:5px;' : '';
+        ?>
+            <tr>
+                <td style="<?= $tdBase ?> text-align:right; font-weight:700; padding-right:8px; <?= $sepStyle ?>">
+                    <?= h($dayLabel) ?>
+                </td>
+                <td style="<?= $tdBase ?> text-align:left; <?= $sepStyle ?>">
+                    <?= nl2br(h($timesText)) ?>
+                </td>
+            </tr>
+        <?php
+            $prevDate = $d;
+        endforeach;
+        ?>
+    </tbody>
+</table>

--- a/templates/element/periode_matricula.php
+++ b/templates/element/periode_matricula.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+$inici = paginesGetYearMaxDate('datainicimatricula');
+$fi = paginesGetYearMaxDate('datafimatricula');
+
+if (!$inici || !$fi) {
+    return;
+}
+
+echo h(sprintf('del %s al %s', paginesFormatCatalanDate($inici), paginesFormatCatalanDate($fi)));

--- a/templates/element/periode_preinscripcio.php
+++ b/templates/element/periode_preinscripcio.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+$inici = paginesGetYearMaxDate('datainicipreinscripcio');
+$fi = paginesGetYearMaxDate('datafipreinscripcio');
+
+if (!$inici || !$fi) {
+    return;
+}
+
+echo h(sprintf('del %s al %s', paginesFormatCatalanDate($inici), paginesFormatCatalanDate($fi)));

--- a/templates/element/periode_reclamacions.php
+++ b/templates/element/periode_reclamacions.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+$inici = paginesGetYearMaxDate('datainicireclamacions');
+$fi = paginesGetYearMaxDate('datafireclamacions');
+
+if (!$inici || !$fi) {
+    return;
+}
+
+echo h(sprintf('del %s al %s', paginesFormatCatalanDate($inici), paginesFormatCatalanDate($fi)));

--- a/templates/element/telefon.php
+++ b/templates/element/telefon.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+echo h(paginesGetConfigValue('telefoncentre'));


### PR DESCRIPTION
### Motivation
- Provide a set of reusable dynamic placeholders for pages so content can include site-wide values and year-based dates.
- Centralize logic to fetch `Configs` and `Years` values and format dates in Catalan to avoid duplication across templates.
- Add an element to render the preinscripcio schedule over a date range using existing `Horarisatencio` data.
- Surface the available dynamic placeholders in the `Pagines` add/edit views as inline help.

### Description
- Added `templates/element/_pagines_dynamic_utils.php` with helper functions `paginesGetConfigValue`, `paginesGetYearMaxDate`, `paginesGetLatestYearFieldValue`, and `paginesFormatCatalanDate` to fetch config/year data and format Catalan dates.
- Added many new element templates under `templates/element/` to expose placeholders: `telefon.php`, `email.php`, `contactevcf.php`, date elements like `data_inici_preinscripcio.php`, `data_fi_preinscripcio.php`, period elements `periode_preinscripcio.php`, `periode_reclamacions.php`, `periode_matricula.php`, field value elements like `dies_caducitat_llista_espera.php`, `dies_no_justificades.php`, and the `horaripreinscripcio.php` element which builds a weekday-by-week table for the working-day range between the max start and end preinscripcio dates and resolves special and regular times from `Horarisatencio`.
- Added help markup to `templates/Pagines/add.php` and `templates/Pagines/edit.php` listing the available placeholder names and brief descriptions.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a17984d5d4832abed87894569ad985)