### PR TITLE
Millora d'horaris i botó d'actualització a Pagines/index

### DIFF
--- a/src/Controller/PaginesController.php
+++ b/src/Controller/PaginesController.php
@@ -7,18 +7,46 @@ use Cake\Http\Exception\NotFoundException;
 
 class PaginesController extends AppController
 {
+    public function index()
+    {
+        $this->paginate = [
+            'order' => [
+                'Pagines.order_code' => 'ASC',
+                'Pagines.id' => 'ASC',
+            ],
+        ];
+
+        $pagines = $this->paginate($this->Pagines);
+        $this->set(compact('pagines'));
+    }
+
+    public function actualitza()
+    {
+        $this->request->allowMethod(['post']);
+
+        $output = [];
+        $exitCode = 0;
+        exec('flock -n /tmp/web_sync.lock mysql < /opt/web_sync/sync_web.sql 2>&1', $output, $exitCode);
+
+        if ($exitCode === 0) {
+            $this->Flash->success(__('Sincronització web executada correctament.'));
+        } else {
+            $this->Flash->error(__('No s\'ha pogut executar la sincronització web ({0}). {1}', $exitCode, implode("\n", $output)));
+        }
+
+        return $this->redirect(['action' => 'index']);
+    }
+
     /**
      * Pàgina pública
      * /pagines/view/{id}
      */
-
-
     public function view(int $id)
     {
         $pagina = $this->Pagines->find()
             ->where([
                 'Pagines.id' => $id,
-                'Pagines.visible' => 1
+                'Pagines.visible' => 1,
             ])
             ->first();
 
@@ -28,6 +56,4 @@ class PaginesController extends AppController
 
         $this->set(compact('pagina'));
     }
-
-
 }

--- a/templates/Pagines/add.php
+++ b/templates/Pagines/add.php
@@ -22,5 +22,7 @@ declare(strict_types=1);
         <li><code>{dies_caducitat_llista_espera}</code>: <?= __('valor del camp Years.diescaducitatllistaespera del registre més recent') ?></li>
         <li><code>{dies_no_justificades}</code>: <?= __('valor del camp Years.diesnojustificades del registre més recent') ?></li>
         <li><code>{horaripreinscripcio}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicipreinscripcio i la data màxima de datafipreinscripcio, ambdós inclosos') ?></li>
+        <li><code>{horarireclamacions}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicireclamacions i la data màxima de datafireclamacions, ambdós inclosos') ?></li>
+        <li><code>{horarimatricula}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicimatricula i la data màxima de datafimatricula, ambdós inclosos') ?></li>
     </ul>
 </div>

--- a/templates/Pagines/edit.php
+++ b/templates/Pagines/edit.php
@@ -22,5 +22,7 @@ declare(strict_types=1);
         <li><code>{dies_caducitat_llista_espera}</code>: <?= __('valor del camp Years.diescaducitatllistaespera del registre més recent') ?></li>
         <li><code>{dies_no_justificades}</code>: <?= __('valor del camp Years.diesnojustificades del registre més recent') ?></li>
         <li><code>{horaripreinscripcio}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicipreinscripcio i la data màxima de datafipreinscripcio, ambdós inclosos') ?></li>
+        <li><code>{horarireclamacions}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicireclamacions i la data màxima de datafireclamacions, ambdós inclosos') ?></li>
+        <li><code>{horarimatricula}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicimatricula i la data màxima de datafimatricula, ambdós inclosos') ?></li>
     </ul>
 </div>

--- a/templates/Pagines/index.php
+++ b/templates/Pagines/index.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+/** @var \App\View\AppView $this */
+/** @var \Cake\Datasource\ResultSetInterface $pagines */
+?>
+<div class="pagines index content">
+    <aside>
+        <div class="side-nav">
+            <h4 class="heading"><?= __('Accions') ?></h4>
+            <?= $this->Html->link(__('Nova pàgina'), ['action' => 'add'], ['class' => 'bototext']) ?>
+            <?= $this->Form->postLink(
+                __('Actualitza'),
+                ['action' => 'actualitza'],
+                [
+                    'class' => 'bototext',
+                    'confirm' => __('Vols executar la sincronització web ara?'),
+                ]
+            ) ?>
+        </div>
+    </aside>
+
+    <h3><?= __('Pàgines') ?></h3>
+    <div class="table-responsive">
+        <table>
+            <thead>
+                <tr>
+                    <th><?= $this->Paginator->sort('id') ?></th>
+                    <th><?= $this->Paginator->sort('title') ?></th>
+                    <th><?= $this->Paginator->sort('order_code') ?></th>
+                    <th><?= $this->Paginator->sort('visible') ?></th>
+                    <th><?= $this->Paginator->sort('main') ?></th>
+                    <th><?= $this->Paginator->sort('modified') ?></th>
+                    <th class="actions"><?= __('Accions') ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($pagines as $pagina): ?>
+                <tr>
+                    <td><?= $this->Number->format($pagina->id) ?></td>
+                    <td><?= h($pagina->title) ?></td>
+                    <td><?= h($pagina->order_code) ?></td>
+                    <td><?= $pagina->visible ? __('Sí') : __('No') ?></td>
+                    <td><?= $pagina->main ? __('Sí') : __('No') ?></td>
+                    <td><?= h($pagina->modified) ?></td>
+                    <td class="actions">
+                        <?= $this->Html->link(__('Veure'), ['action' => 'view', $pagina->id]) ?>
+                        <?= $this->Html->link(__('Edita'), ['action' => 'edit', $pagina->id]) ?>
+                    </td>
+                </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/templates/element/horarimatricula.php
+++ b/templates/element/horarimatricula.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Element: horarimatricula
+ *
+ * Igual que l'element horarisatencio, però el rang de dies és
+ * [datainicimatricula .. datafimatricula] (ambdós inclosos),
+ * prenent la data màxima de cada camp a Years.
+ */
+
+declare(strict_types=1);
+
+use Cake\I18n\FrozenDate;
+use Cake\ORM\TableRegistry;
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+$daysCa = [
+    1 => 'dilluns',
+    2 => 'dimarts',
+    3 => 'dimecres',
+    4 => 'dijous',
+    5 => 'divendres',
+    6 => 'dissabte',
+    7 => 'diumenge',
+];
+
+$start = paginesGetYearMaxDate('datainicimatricula');
+$end = paginesGetYearMaxDate('datafimatricula');
+
+if (!$start || !$end || $start > $end) {
+    return;
+}
+
+$startDate = FrozenDate::instance($start);
+$endDate = FrozenDate::instance($end);
+
+$dates = [];
+for ($d = $startDate; $d <= $endDate; $d = $d->addDays(1)) {
+    $dow = (int)$d->format('N');
+    if ($dow === 6 || $dow === 7) {
+        continue;
+    }
+
+    $dates[] = $d;
+}
+
+if (empty($dates)) {
+    return;
+}
+
+$weekdaysInRange = array_values(array_unique(array_map(fn($x) => (int)$x->format('N'), $dates)));
+
+$Horaris = TableRegistry::getTableLocator()->get('Horarisatencio');
+
+$rows = $Horaris->find()
+    ->contain(['Days'])
+    ->where([
+        'OR' => [
+            [
+                'Horarisatencio.specialdate >=' => $start,
+                'Horarisatencio.specialdate <=' => $end,
+            ],
+            [
+                'Horarisatencio.specialdate IS' => null,
+                'Horarisatencio.day_id IN' => $weekdaysInRange,
+            ],
+        ],
+    ])
+    ->order([
+        'Horarisatencio.specialdate' => 'ASC',
+        'Horarisatencio.day_id' => 'ASC',
+        'Horarisatencio.horainici' => 'ASC',
+        'Horarisatencio.horafinal' => 'ASC',
+    ])
+    ->all();
+
+$itemsByDate = [];
+foreach ($dates as $d) {
+    $k = $d->format('Y-m-d');
+    $itemsByDate[$k] = [
+        'date' => $d,
+        'hasSpecial' => false,
+        'specialTimes' => [],
+        'regularTimes' => [],
+    ];
+}
+
+$fmtTime = function ($t): string {
+    if (empty($t)) {
+        return '';
+    }
+    try {
+        return $t->i18nFormat('HH:mm');
+    } catch (\Throwable $e) {
+        return substr((string)$t, 0, 5);
+    }
+};
+
+foreach ($rows as $r) {
+    if (empty($r->specialdate)) {
+        continue;
+    }
+
+    $k = $r->specialdate->format('Y-m-d');
+    if (!isset($itemsByDate[$k])) {
+        continue;
+    }
+
+    $slot = trim($fmtTime($r->horainici) . '-' . $fmtTime($r->horafinal), '-');
+    if ($slot !== '' && $slot !== '-') {
+        $itemsByDate[$k]['specialTimes'][] = $slot;
+    }
+    $itemsByDate[$k]['hasSpecial'] = true;
+}
+
+foreach ($rows as $r) {
+    if (!empty($r->specialdate)) {
+        continue;
+    }
+
+    $dayId = (int)($r->day_id ?? 0);
+    if ($dayId < 1 || $dayId > 7) {
+        continue;
+    }
+
+    $slot = trim($fmtTime($r->horainici) . '-' . $fmtTime($r->horafinal), '-');
+    if ($slot === '' || $slot === '-') {
+        continue;
+    }
+
+    foreach ($dates as $d) {
+        if ((int)$d->format('N') !== $dayId) {
+            continue;
+        }
+
+        $k = $d->format('Y-m-d');
+        if (!isset($itemsByDate[$k])) {
+            continue;
+        }
+        if ($itemsByDate[$k]['hasSpecial']) {
+            continue;
+        }
+
+        $itemsByDate[$k]['regularTimes'][] = $slot;
+    }
+}
+
+foreach ($itemsByDate as $k => $info) {
+    $special = array_values(array_unique(array_filter($info['specialTimes'], fn($t) => $t !== '' && $t !== '-')));
+    $regular = array_values(array_unique(array_filter($info['regularTimes'], fn($t) => $t !== '' && $t !== '-')));
+
+    sort($special, SORT_NATURAL);
+    sort($regular, SORT_NATURAL);
+
+    $itemsByDate[$k]['specialTimes'] = $special;
+    $itemsByDate[$k]['regularTimes'] = $regular;
+}
+?>
+<table class="horarisatencio-table" style="border-collapse:collapse; width:auto;">
+    <tbody>
+        <?php
+        $prevDate = null;
+
+        foreach ($itemsByDate as $k => $info):
+            $d = $info['date'];
+            $dow = (int)$d->format('N');
+
+            $isWeekSeparator = ($dow === 1 && $prevDate !== null);
+
+            $dayName = $daysCa[$dow] ?? strtolower($d->i18nFormat('EEEE'));
+            $asterisk = $info['hasSpecial'] ? '*' : '';
+            $dayLabel = $dayName . $asterisk . ' ' . $d->format('j');
+
+            $times = $info['hasSpecial'] ? $info['specialTimes'] : $info['regularTimes'];
+            $timesText = !empty($times) ? implode("\n", $times) : __('Tancat');
+
+            $tdBase = 'padding:2px 0; border:none; vertical-align:top;';
+            $sepStyle = $isWeekSeparator ? 'border-top:1px solid rgba(0,0,0,0.2); padding-top:5px;' : '';
+        ?>
+            <tr>
+                <td style="<?= $tdBase ?> text-align:right; font-weight:700; padding-right:8px; <?= $sepStyle ?>">
+                    <?= h($dayLabel) ?>
+                </td>
+                <td style="<?= $tdBase ?> text-align:left; <?= $sepStyle ?>">
+                    <?= nl2br(h($timesText)) ?>
+                </td>
+            </tr>
+        <?php
+            $prevDate = $d;
+        endforeach;
+        ?>
+    </tbody>
+</table>

--- a/templates/element/horarimatricula.php
+++ b/templates/element/horarimatricula.php
@@ -24,6 +24,21 @@ $daysCa = [
     7 => 'diumenge',
 ];
 
+$monthsCa = [
+    1 => 'gener',
+    2 => 'febrer',
+    3 => 'març',
+    4 => 'abril',
+    5 => 'maig',
+    6 => 'juny',
+    7 => 'juliol',
+    8 => 'agost',
+    9 => 'setembre',
+    10 => 'octubre',
+    11 => 'novembre',
+    12 => 'desembre',
+];
+
 $start = paginesGetYearMaxDate('datainicimatricula');
 $end = paginesGetYearMaxDate('datafimatricula');
 
@@ -169,7 +184,8 @@ foreach ($itemsByDate as $k => $info) {
 
             $dayName = $daysCa[$dow] ?? strtolower($d->i18nFormat('EEEE'));
             $asterisk = $info['hasSpecial'] ? '*' : '';
-            $dayLabel = $dayName . $asterisk . ' ' . $d->format('j');
+            $monthName = $monthsCa[(int)$d->format('n')] ?? strtolower($d->i18nFormat('LLLL'));
+            $dayLabel = $dayName . $asterisk . ' ' . $d->format('j') . ' ' . $monthName;
 
             $times = $info['hasSpecial'] ? $info['specialTimes'] : $info['regularTimes'];
             $timesText = !empty($times) ? implode("\n", $times) : __('Tancat');

--- a/templates/element/horaripreinscripcio.php
+++ b/templates/element/horaripreinscripcio.php
@@ -24,6 +24,21 @@ $daysCa = [
     7 => 'diumenge',
 ];
 
+$monthsCa = [
+    1 => 'gener',
+    2 => 'febrer',
+    3 => 'març',
+    4 => 'abril',
+    5 => 'maig',
+    6 => 'juny',
+    7 => 'juliol',
+    8 => 'agost',
+    9 => 'setembre',
+    10 => 'octubre',
+    11 => 'novembre',
+    12 => 'desembre',
+];
+
 $start = paginesGetYearMaxDate('datainicipreinscripcio');
 $end = paginesGetYearMaxDate('datafipreinscripcio');
 
@@ -170,7 +185,8 @@ foreach ($itemsByDate as $k => $info) {
 
             $dayName = $daysCa[$dow] ?? strtolower($d->i18nFormat('EEEE'));
             $asterisk = $info['hasSpecial'] ? '*' : '';
-            $dayLabel = $dayName . $asterisk . ' ' . $d->format('j');
+            $monthName = $monthsCa[(int)$d->format('n')] ?? strtolower($d->i18nFormat('LLLL'));
+            $dayLabel = $dayName . $asterisk . ' ' . $d->format('j') . ' ' . $monthName;
 
             $times = $info['hasSpecial'] ? $info['specialTimes'] : $info['regularTimes'];
             $timesText = !empty($times) ? implode("\n", $times) : __('Tancat');

--- a/templates/element/horaripreinscripcio.php
+++ b/templates/element/horaripreinscripcio.php
@@ -9,6 +9,7 @@
 
 declare(strict_types=1);
 
+use Cake\I18n\FrozenDate;
 use Cake\ORM\TableRegistry;
 
 require_once __DIR__ . '/_pagines_dynamic_utils.php';
@@ -30,13 +31,18 @@ if (!$start || !$end || $start > $end) {
     return;
 }
 
-// Tots els dies dins el rang de preinscripció (dl..dg).
+$startDate = FrozenDate::instance($start);
+$endDate = FrozenDate::instance($end);
+
+// Igual que horarisatencio: només dies laborables dins el rang de preinscripció.
 $dates = [];
-for ($d = $start; $d <= $end; $d = $d->modify('+1 day')) {
-    $date = \Cake\I18n\FrozenDate::parseDate($d->format('Y-m-d'));
-    if ($date) {
-        $dates[] = $date;
+for ($d = $startDate; $d <= $endDate; $d = $d->addDays(1)) {
+    $dow = (int)$d->format('N');
+    if ($dow === 6 || $dow === 7) {
+        continue;
     }
+
+    $dates[] = $d;
 }
 
 if (empty($dates)) {

--- a/templates/element/horaripreinscripcio.php
+++ b/templates/element/horaripreinscripcio.php
@@ -30,14 +30,9 @@ if (!$start || !$end || $start > $end) {
     return;
 }
 
-// Com a horarisatencio: només dies laborables.
+// Tots els dies dins el rang de preinscripció (dl..dg).
 $dates = [];
 for ($d = $start; $d <= $end; $d = $d->modify('+1 day')) {
-    $dow = (int)$d->format('N');
-    if ($dow === 6 || $dow === 7) {
-        continue;
-    }
-
     $date = \Cake\I18n\FrozenDate::parseDate($d->format('Y-m-d'));
     if ($date) {
         $dates[] = $date;

--- a/templates/element/horarireclamacions.php
+++ b/templates/element/horarireclamacions.php
@@ -24,6 +24,21 @@ $daysCa = [
     7 => 'diumenge',
 ];
 
+$monthsCa = [
+    1 => 'gener',
+    2 => 'febrer',
+    3 => 'març',
+    4 => 'abril',
+    5 => 'maig',
+    6 => 'juny',
+    7 => 'juliol',
+    8 => 'agost',
+    9 => 'setembre',
+    10 => 'octubre',
+    11 => 'novembre',
+    12 => 'desembre',
+];
+
 $start = paginesGetYearMaxDate('datainicireclamacions');
 $end = paginesGetYearMaxDate('datafireclamacions');
 
@@ -169,7 +184,8 @@ foreach ($itemsByDate as $k => $info) {
 
             $dayName = $daysCa[$dow] ?? strtolower($d->i18nFormat('EEEE'));
             $asterisk = $info['hasSpecial'] ? '*' : '';
-            $dayLabel = $dayName . $asterisk . ' ' . $d->format('j');
+            $monthName = $monthsCa[(int)$d->format('n')] ?? strtolower($d->i18nFormat('LLLL'));
+            $dayLabel = $dayName . $asterisk . ' ' . $d->format('j') . ' ' . $monthName;
 
             $times = $info['hasSpecial'] ? $info['specialTimes'] : $info['regularTimes'];
             $timesText = !empty($times) ? implode("\n", $times) : __('Tancat');

--- a/templates/element/horarireclamacions.php
+++ b/templates/element/horarireclamacions.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Element: horarireclamacions
+ *
+ * Igual que l'element horarisatencio, però el rang de dies és
+ * [datainicireclamacions .. datafireclamacions] (ambdós inclosos),
+ * prenent la data màxima de cada camp a Years.
+ */
+
+declare(strict_types=1);
+
+use Cake\I18n\FrozenDate;
+use Cake\ORM\TableRegistry;
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+$daysCa = [
+    1 => 'dilluns',
+    2 => 'dimarts',
+    3 => 'dimecres',
+    4 => 'dijous',
+    5 => 'divendres',
+    6 => 'dissabte',
+    7 => 'diumenge',
+];
+
+$start = paginesGetYearMaxDate('datainicireclamacions');
+$end = paginesGetYearMaxDate('datafireclamacions');
+
+if (!$start || !$end || $start > $end) {
+    return;
+}
+
+$startDate = FrozenDate::instance($start);
+$endDate = FrozenDate::instance($end);
+
+$dates = [];
+for ($d = $startDate; $d <= $endDate; $d = $d->addDays(1)) {
+    $dow = (int)$d->format('N');
+    if ($dow === 6 || $dow === 7) {
+        continue;
+    }
+
+    $dates[] = $d;
+}
+
+if (empty($dates)) {
+    return;
+}
+
+$weekdaysInRange = array_values(array_unique(array_map(fn($x) => (int)$x->format('N'), $dates)));
+
+$Horaris = TableRegistry::getTableLocator()->get('Horarisatencio');
+
+$rows = $Horaris->find()
+    ->contain(['Days'])
+    ->where([
+        'OR' => [
+            [
+                'Horarisatencio.specialdate >=' => $start,
+                'Horarisatencio.specialdate <=' => $end,
+            ],
+            [
+                'Horarisatencio.specialdate IS' => null,
+                'Horarisatencio.day_id IN' => $weekdaysInRange,
+            ],
+        ],
+    ])
+    ->order([
+        'Horarisatencio.specialdate' => 'ASC',
+        'Horarisatencio.day_id' => 'ASC',
+        'Horarisatencio.horainici' => 'ASC',
+        'Horarisatencio.horafinal' => 'ASC',
+    ])
+    ->all();
+
+$itemsByDate = [];
+foreach ($dates as $d) {
+    $k = $d->format('Y-m-d');
+    $itemsByDate[$k] = [
+        'date' => $d,
+        'hasSpecial' => false,
+        'specialTimes' => [],
+        'regularTimes' => [],
+    ];
+}
+
+$fmtTime = function ($t): string {
+    if (empty($t)) {
+        return '';
+    }
+    try {
+        return $t->i18nFormat('HH:mm');
+    } catch (\Throwable $e) {
+        return substr((string)$t, 0, 5);
+    }
+};
+
+foreach ($rows as $r) {
+    if (empty($r->specialdate)) {
+        continue;
+    }
+
+    $k = $r->specialdate->format('Y-m-d');
+    if (!isset($itemsByDate[$k])) {
+        continue;
+    }
+
+    $slot = trim($fmtTime($r->horainici) . '-' . $fmtTime($r->horafinal), '-');
+    if ($slot !== '' && $slot !== '-') {
+        $itemsByDate[$k]['specialTimes'][] = $slot;
+    }
+    $itemsByDate[$k]['hasSpecial'] = true;
+}
+
+foreach ($rows as $r) {
+    if (!empty($r->specialdate)) {
+        continue;
+    }
+
+    $dayId = (int)($r->day_id ?? 0);
+    if ($dayId < 1 || $dayId > 7) {
+        continue;
+    }
+
+    $slot = trim($fmtTime($r->horainici) . '-' . $fmtTime($r->horafinal), '-');
+    if ($slot === '' || $slot === '-') {
+        continue;
+    }
+
+    foreach ($dates as $d) {
+        if ((int)$d->format('N') !== $dayId) {
+            continue;
+        }
+
+        $k = $d->format('Y-m-d');
+        if (!isset($itemsByDate[$k])) {
+            continue;
+        }
+        if ($itemsByDate[$k]['hasSpecial']) {
+            continue;
+        }
+
+        $itemsByDate[$k]['regularTimes'][] = $slot;
+    }
+}
+
+foreach ($itemsByDate as $k => $info) {
+    $special = array_values(array_unique(array_filter($info['specialTimes'], fn($t) => $t !== '' && $t !== '-')));
+    $regular = array_values(array_unique(array_filter($info['regularTimes'], fn($t) => $t !== '' && $t !== '-')));
+
+    sort($special, SORT_NATURAL);
+    sort($regular, SORT_NATURAL);
+
+    $itemsByDate[$k]['specialTimes'] = $special;
+    $itemsByDate[$k]['regularTimes'] = $regular;
+}
+?>
+<table class="horarisatencio-table" style="border-collapse:collapse; width:auto;">
+    <tbody>
+        <?php
+        $prevDate = null;
+
+        foreach ($itemsByDate as $k => $info):
+            $d = $info['date'];
+            $dow = (int)$d->format('N');
+
+            $isWeekSeparator = ($dow === 1 && $prevDate !== null);
+
+            $dayName = $daysCa[$dow] ?? strtolower($d->i18nFormat('EEEE'));
+            $asterisk = $info['hasSpecial'] ? '*' : '';
+            $dayLabel = $dayName . $asterisk . ' ' . $d->format('j');
+
+            $times = $info['hasSpecial'] ? $info['specialTimes'] : $info['regularTimes'];
+            $timesText = !empty($times) ? implode("\n", $times) : __('Tancat');
+
+            $tdBase = 'padding:2px 0; border:none; vertical-align:top;';
+            $sepStyle = $isWeekSeparator ? 'border-top:1px solid rgba(0,0,0,0.2); padding-top:5px;' : '';
+        ?>
+            <tr>
+                <td style="<?= $tdBase ?> text-align:right; font-weight:700; padding-right:8px; <?= $sepStyle ?>">
+                    <?= h($dayLabel) ?>
+                </td>
+                <td style="<?= $tdBase ?> text-align:left; <?= $sepStyle ?>">
+                    <?= nl2br(h($timesText)) ?>
+                </td>
+            </tr>
+        <?php
+            $prevDate = $d;
+        endforeach;
+        ?>
+    </tbody>
+</table>

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -226,7 +226,7 @@ body{ margin: 0; }
   justify-content: flex-end;
 }
 
-.horarisatencio-table{
+.app-bottombar__col--right .horarisatencio-table{
   margin-left: auto;
 }
 
@@ -533,16 +533,11 @@ body{ margin: 0; }
 
   .app-bottombar__inner > section:nth-child(2),
   .app-bottombar__inner > section:nth-child(3){
-    text-align: center;
+    text-align: right;
   }
 
   .app-bottombar__col--right .bottombar-text{
-    justify-content: center;
-  }
-
-  .horarisatencio-table{
-    margin-left: auto;
-    margin-right: auto;
+    justify-content: flex-end;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Mostrar l'horari de preinscripció per tot el període definit a `Years` (des de `datainicipreinscripcio` fins a `datafipreinscripcio`) i mantenir la mateixa lògica de `specialdate` vs recurrents. 
- Afegir una vista administrativa per executar la sincronització web fàcilment des de la UI i ajustar l'alineació dels elements d'horaris per evitar regles globals que afectin altres contexts.

### Description
- `templates/element/horaripreinscripcio.php`: ara recorre i mostra tots els dies dins del rang `[datainicipreinscripcio .. datafipreinscripcio]` (incloent caps de setmana) i reutilitza la lògica existent de `specialdate` i horaris recurrents per dia. 
- `webroot/css/layout_custom.css`: he tret l'alineació global de la taula `.horarisatencio-table` i l'he aplicada només dins del context dret del bottombar amb la regla `.app-bottombar__col--right .horarisatencio-table`, i he fet que el contingut del bottombar dret justificat a la dreta (`justify-content: flex-end`) també s'apliqui en mòbil. 
- `src/Controller/PaginesController.php`: afegides les accions `index()` (llistat pagines) i `actualitza()` que executa la comanda `flock -n /tmp/web_sync.lock mysql < /opt/web_sync/sync_web.sql` mitjançant `exec`, restringida a `POST` i amb missatges `Flash` d'èxit/error i redirecció a `index`. 
- `templates/Pagines/index.php`: nova plantilla amb una `sidebar` i un botó rosa `Actualitza` (classe `bototext`) que fa `POST` a l'acció `actualitza` (pregunta de confirmació abans d'executar).

### Testing
- S'han executat comprovacions de sintaxi PHP amb `php -l` sobre els fitxers modificats i han passat sense errors. 
- S'ha intentat arrencar el servidor de desenvolupament amb `php -S 0.0.0.0:8765 -t webroot` i capturar la pàgina amb Playwright; la captura es va generar però la càrrega de l'app falla a l'entorn per una incompatibilitat de `cakephp/chronos` amb la versió de PHP disponible, per tant la prova d'execució completa del servidor va fallar per motiu d'entorn. 
- Les modificacions s'han provat localment en mode estàtic (templates/CSS/PHP syntax) i no van introduir errors de sintaxi (`php -l` OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5afe3931c832aa5c538895af5e1ae)