### PR TITLE
Fix mobile overlap and make page tables responsive

### DIFF
--- a/templates/Pagines/view.php
+++ b/templates/Pagines/view.php
@@ -107,6 +107,10 @@ $body = $renderDynamicElements($body);
         align-items: center;
     }
 
+    .popup-menuppal__scroll.popup-menuppal__scroll--top {
+        justify-content: flex-start;
+    }
+
     .popup-menuppal__content {
         width: 100%;
         max-width: 1100px;
@@ -169,6 +173,8 @@ $body = $renderDynamicElements($body);
     (function () {
         const modal = document.getElementById('popupMenuppal');
         const closeBtn = document.getElementById('popupMenuppalClose');
+        const scrollContainer = modal ? modal.querySelector('.popup-menuppal__scroll') : null;
+        const content = modal ? modal.querySelector('.popup-menuppal__content') : null;
         if (!modal || !closeBtn) {
             return;
         }
@@ -177,7 +183,23 @@ $body = $renderDynamicElements($body);
             document.body.appendChild(modal);
         }
 
+        function updatePopupVerticalAlignment() {
+            if (!scrollContainer || !content) {
+                return;
+            }
+
+            const availableHeight = window.innerHeight - 64;
+            const contentHeight = content.offsetHeight + closeBtn.offsetHeight + 24;
+            const shouldAlignTop = contentHeight > availableHeight;
+
+            scrollContainer.classList.toggle('popup-menuppal__scroll--top', shouldAlignTop);
+        }
+
+        updatePopupVerticalAlignment();
+        window.addEventListener('resize', updatePopupVerticalAlignment);
+
         closeBtn.addEventListener('click', function () {
+            window.removeEventListener('resize', updatePopupVerticalAlignment);
             modal.remove();
         });
     })();

--- a/templates/Pagines/view.php
+++ b/templates/Pagines/view.php
@@ -88,11 +88,6 @@ if ($body !== '') {
                 return;
             }
 
-            const shouldStack = table.scrollWidth > table.clientWidth;
-            if (!shouldStack) {
-                return;
-            }
-
             const labels = getHeaderLabels(table);
             const rows = table.querySelectorAll('tr');
             const hasThead = table.querySelector('thead') !== null;

--- a/templates/Pagines/view.php
+++ b/templates/Pagines/view.php
@@ -60,17 +60,7 @@ if ($body !== '') {
 
         if (headerCells.length > 0) {
             headerCells.forEach((cell) => labels.push((cell.textContent || '').trim()));
-            return labels;
         }
-
-        const firstRow = table.querySelector('tr');
-        if (!firstRow) {
-            return labels;
-        }
-
-        firstRow.querySelectorAll('th, td').forEach((cell) => {
-            labels.push((cell.textContent || '').trim());
-        });
 
         return labels;
     }
@@ -121,8 +111,8 @@ if ($body !== '') {
 
         tables.forEach((table) => {
             table.classList.remove('table-stack-mobile');
-            table.classList.remove('table-stack-mobile--no-thead');
             table.classList.remove('table-mobile-scroll');
+            table.classList.remove('table-stack-mobile--plain-rows');
             table.querySelectorAll('td, th').forEach((cell) => {
                 cell.removeAttribute('data-label');
             });
@@ -130,6 +120,13 @@ if ($body !== '') {
             unwrapScrollableTable(table);
 
             if (!MOBILE_QUERY.matches) {
+                return;
+            }
+
+            const hasThead = table.querySelector('thead') !== null;
+
+            if (!hasThead) {
+                table.classList.add('table-stack-mobile', 'table-stack-mobile--plain-rows');
                 return;
             }
 
@@ -141,14 +138,8 @@ if ($body !== '') {
 
             const labels = getHeaderLabels(table);
             const rows = table.querySelectorAll('tr');
-            const hasThead = table.querySelector('thead') !== null;
-            table.classList.toggle('table-stack-mobile--no-thead', !hasThead);
 
-            rows.forEach((row, rowIndex) => {
-                if (!hasThead && rowIndex === 0) {
-                    return;
-                }
-
+            rows.forEach((row) => {
                 row.querySelectorAll('th, td').forEach((cell, index) => {
                     const label = labels[index] || '';
                     cell.setAttribute('data-label', label);

--- a/templates/Pagines/view.php
+++ b/templates/Pagines/view.php
@@ -134,15 +134,43 @@ $body = $renderDynamicElements($body);
 
     <script>
     (function () {
+        console.info('[menuppal-popup] init', {
+            isMenuPpalPage: true,
+            popupBodyLength: <?= json_encode(strlen($popupBody)) ?>
+        });
+
         const modal = document.getElementById('popupMenuppal');
         const closeBtn = document.getElementById('popupMenuppalClose');
         if (!modal || !closeBtn) {
+            console.warn('[menuppal-popup] modal o boto no trobats', {
+                modalFound: Boolean(modal),
+                closeBtnFound: Boolean(closeBtn)
+            });
             return;
         }
 
+        console.info('[menuppal-popup] modal visible');
+
         closeBtn.addEventListener('click', function () {
+            console.info('[menuppal-popup] tancat per usuari');
             modal.remove();
         });
+    })();
+    </script>
+<?php endif; ?>
+
+<?php if ($isMenuPpalPage): ?>
+    <script>
+    (function () {
+        console.info('[menuppal] pagina carregada', {
+            isMenuPpalPage: true,
+            popupPresent: <?= json_encode($popupBody !== '') ?>,
+            popupBodyLength: <?= json_encode(strlen($popupBody)) ?>
+        });
+
+        if (!<?= json_encode($popupBody !== '') ?>) {
+            console.warn('[menuppal] no hi ha cap pagina amb popup=1 o body buit');
+        }
     })();
     </script>
 <?php endif; ?>

--- a/templates/Pagines/view.php
+++ b/templates/Pagines/view.php
@@ -80,6 +80,7 @@ if ($body !== '') {
 
         tables.forEach((table) => {
             table.classList.remove('table-stack-mobile');
+            table.classList.remove('table-stack-mobile--no-thead');
             table.querySelectorAll('td, th').forEach((cell) => {
                 cell.removeAttribute('data-label');
             });
@@ -91,6 +92,7 @@ if ($body !== '') {
             const labels = getHeaderLabels(table);
             const rows = table.querySelectorAll('tr');
             const hasThead = table.querySelector('thead') !== null;
+            table.classList.toggle('table-stack-mobile--no-thead', !hasThead);
 
             rows.forEach((row, rowIndex) => {
                 if (!hasThead && rowIndex === 0) {

--- a/templates/Pagines/view.php
+++ b/templates/Pagines/view.php
@@ -9,17 +9,14 @@ $this->assign('title', $pagina->title ?? 'Pàgina');
 $body = (string)($pagina->body ?? '');
 $isMenuPpalPage = str_contains($body, '{menuppal}') || str_contains($body, '&#123;menuppal&#125;');
 
-if ($isMenuPpalPage) {
-    $this->assign('appMainClass', 'has-menuppal app-main--centered');
-}
+$renderDynamicElements = function (string $html): string {
+    if ($html === '') {
+        return $html;
+    }
 
-if ($body !== '') {
-    // Regex que captura:
-    //  - {element}
-    //  - &#123;element&#125;
     $pattern = '/(?:\{|\&\#123;)\s*([a-zA-Z0-9_-]+)\s*(?:\}|\&\#125;)/';
 
-    $body = preg_replace_callback($pattern, function ($m) {
+    return preg_replace_callback($pattern, function ($m) {
         $elementName = $m[1];
 
         if ($elementName === '' || str_contains($elementName, '..') || str_contains($elementName, '/')) {
@@ -34,12 +31,32 @@ if ($body !== '') {
         $elementHtml = $this->element($elementName);
 
         return sprintf(
-            "<div class=\"pagina-element pagina-element--%s\">%s</div>",
+            '<div class="pagina-element pagina-element--%s">%s</div>',
             h($elementName),
             $elementHtml
         );
-    }, $body);
+    }, $html);
+};
+
+$popupBody = '';
+
+if ($isMenuPpalPage) {
+    $this->assign('appMainClass', 'has-menuppal app-main--centered');
+
+    $Pagines = \Cake\ORM\TableRegistry::getTableLocator()->get('Pagines');
+    $popupPagina = $Pagines->find()
+        ->select(['body'])
+        ->where(['popup' => 1])
+        ->order(['id' => 'DESC'])
+        ->first();
+
+    if ($popupPagina !== null) {
+        $popupBody = (string)($popupPagina->body ?? '');
+        $popupBody = $renderDynamicElements($popupBody);
+    }
 }
+
+$body = $renderDynamicElements($body);
 ?>
 
 <div class="pagines view content">
@@ -49,6 +66,86 @@ if ($body !== '') {
     </div>
 
 </div>
+
+<?php if ($popupBody !== ''): ?>
+    <div class="popup-menuppal" id="popupMenuppal" role="dialog" aria-modal="true" aria-label="Avís important">
+        <button type="button" class="popup-menuppal__close" id="popupMenuppalClose">TANCA</button>
+        <div class="popup-menuppal__content">
+            <?= $this->Html->div(null, $popupBody, ['escape' => false]) ?>
+        </div>
+    </div>
+
+    <style>
+    .popup-menuppal {
+        position: fixed;
+        inset: 0;
+        z-index: 999999;
+        background: #e55381;
+        color: #fff;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 2rem;
+    }
+
+    .popup-menuppal__content {
+        width: 100%;
+        max-width: 1100px;
+        max-height: 100%;
+        overflow: auto;
+        font-family: "Roboto Condensed", "Roboto", sans-serif;
+        font-size: 2rem;
+        line-height: 1.25;
+        color: #fff;
+    }
+
+    .popup-menuppal__content table:not([border]):not([style*="border"]),
+    .popup-menuppal__content table:not([border]):not([style*="border"]) td:not([style*="border"]),
+    .popup-menuppal__content table:not([border]):not([style*="border"]) th:not([style*="border"]) {
+        border: 0 !important;
+    }
+
+    .popup-menuppal__content h1,
+    .popup-menuppal__content h2,
+    .popup-menuppal__content h3 {
+        width: 100%;
+        margin: 0 0 1rem 0;
+        padding: 0.5em;
+        background: #708090;
+        color: #fff;
+        font-family: "Bebas Neue", sans-serif;
+        font-size: 3rem;
+        line-height: 1;
+    }
+
+    .popup-menuppal__close {
+        position: absolute;
+        top: 1rem;
+        right: 1rem;
+        border: 2px solid #fff;
+        background: transparent;
+        color: #fff;
+        font-family: "Bebas Neue", sans-serif;
+        font-size: 1.25rem;
+        padding: 0.35rem 0.75rem;
+        cursor: pointer;
+    }
+    </style>
+
+    <script>
+    (function () {
+        const modal = document.getElementById('popupMenuppal');
+        const closeBtn = document.getElementById('popupMenuppalClose');
+        if (!modal || !closeBtn) {
+            return;
+        }
+
+        closeBtn.addEventListener('click', function () {
+            modal.remove();
+        });
+    })();
+    </script>
+<?php endif; ?>
 
 <script>
 (function () {

--- a/templates/Pagines/view.php
+++ b/templates/Pagines/view.php
@@ -153,6 +153,7 @@ $body = $renderDynamicElements($body);
         font-family: "Bebas Neue", sans-serif;
         font-size: 1.6rem;
         padding: 0.55rem 1.5rem;
+        margin: 1rem;
         cursor: pointer;
     }
 

--- a/templates/Pagines/view.php
+++ b/templates/Pagines/view.php
@@ -75,17 +75,67 @@ if ($body !== '') {
         return labels;
     }
 
+    function isComplexTable(table) {
+        if (table.querySelector('[rowspan], [colspan]')) {
+            return true;
+        }
+
+        const rows = Array.from(table.querySelectorAll('tr'));
+        const dataRows = rows.filter((row) => row.closest('thead') === null);
+        const firstDataRow = dataRows[0] || rows[0] || null;
+        if (!firstDataRow) {
+            return false;
+        }
+
+        const expectedCells = firstDataRow.querySelectorAll('th, td').length;
+        if (expectedCells === 0) {
+            return false;
+        }
+
+        return dataRows.some((row) => row.querySelectorAll('th, td').length !== expectedCells);
+    }
+
+    function wrapScrollableTable(table) {
+        const parent = table.parentElement;
+        if (!parent || parent.classList.contains('table-mobile-scroll-wrap')) {
+            return;
+        }
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'table-mobile-scroll-wrap';
+        parent.insertBefore(wrapper, table);
+        wrapper.appendChild(table);
+    }
+
+    function unwrapScrollableTable(table) {
+        const parent = table.parentElement;
+        if (!parent || !parent.classList.contains('table-mobile-scroll-wrap')) {
+            return;
+        }
+
+        parent.replaceWith(table);
+    }
+
     function applyResponsiveTables() {
         const tables = document.querySelectorAll('.pagina-body table, .pagina-body-main table');
 
         tables.forEach((table) => {
             table.classList.remove('table-stack-mobile');
             table.classList.remove('table-stack-mobile--no-thead');
+            table.classList.remove('table-mobile-scroll');
             table.querySelectorAll('td, th').forEach((cell) => {
                 cell.removeAttribute('data-label');
             });
 
+            unwrapScrollableTable(table);
+
             if (!MOBILE_QUERY.matches) {
+                return;
+            }
+
+            if (isComplexTable(table)) {
+                table.classList.add('table-mobile-scroll');
+                wrapScrollableTable(table);
                 return;
             }
 

--- a/templates/Pagines/view.php
+++ b/templates/Pagines/view.php
@@ -69,9 +69,13 @@ $body = $renderDynamicElements($body);
 
 <?php if ($popupBody !== ''): ?>
     <div class="popup-menuppal" id="popupMenuppal" role="dialog" aria-modal="true" aria-label="Avís important">
-        <button type="button" class="popup-menuppal__close" id="popupMenuppalClose">TANCA</button>
-        <div class="popup-menuppal__content">
-            <?= $this->Html->div(null, $popupBody, ['escape' => false]) ?>
+        <div class="popup-menuppal__scroll">
+            <div class="popup-menuppal__content">
+                <?= $this->Html->div(null, $popupBody, ['escape' => false]) ?>
+                <div class="popup-menuppal__actions">
+                    <button type="button" class="popup-menuppal__close" id="popupMenuppalClose">TANCA</button>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -88,10 +92,18 @@ $body = $renderDynamicElements($body);
         background: #e55381;
         color: #fff;
         display: flex;
-        justify-content: center;
-        align-items: center;
         padding: 2rem;
         isolation: isolate;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+
+    .popup-menuppal__scroll {
+        width: 100%;
+        min-height: calc(100vh - 4rem);
+        display: flex;
+        justify-content: center;
+        align-items: center;
     }
 
     .popup-menuppal__content {
@@ -103,6 +115,13 @@ $body = $renderDynamicElements($body);
         font-size: 2rem;
         line-height: 1.25;
         color: #fff;
+    }
+
+    .popup-menuppal__actions {
+        width: 100%;
+        display: flex;
+        justify-content: center;
+        margin-top: 1.25rem;
     }
 
     .popup-menuppal__content table:not([border]):not([style*="border"]),
@@ -125,16 +144,25 @@ $body = $renderDynamicElements($body);
     }
 
     .popup-menuppal__close {
-        position: absolute;
-        top: 1rem;
-        right: 1rem;
-        border: 2px solid #fff;
-        background: transparent;
+        border: 0;
+        background: #708090;
         color: #fff;
         font-family: "Bebas Neue", sans-serif;
         font-size: 1.25rem;
         padding: 0.35rem 0.75rem;
         cursor: pointer;
+    }
+
+    @media (max-width: 900px) {
+        .popup-menuppal__content {
+            font-size: 1rem;
+        }
+
+        .popup-menuppal__content h1,
+        .popup-menuppal__content h2,
+        .popup-menuppal__content h3 {
+            font-size: 2rem;
+        }
     }
     </style>
 

--- a/templates/Pagines/view.php
+++ b/templates/Pagines/view.php
@@ -72,9 +72,9 @@ $body = $renderDynamicElements($body);
         <div class="popup-menuppal__scroll">
             <div class="popup-menuppal__content">
                 <?= $this->Html->div(null, $popupBody, ['escape' => false]) ?>
-                <div class="popup-menuppal__actions">
-                    <button type="button" class="popup-menuppal__close" id="popupMenuppalClose">TANCA</button>
-                </div>
+            </div>
+            <div class="popup-menuppal__actions">
+                <button type="button" class="popup-menuppal__close" id="popupMenuppalClose">TANCA</button>
             </div>
         </div>
     </div>
@@ -102,6 +102,7 @@ $body = $renderDynamicElements($body);
         width: 100%;
         min-height: calc(100vh - 4rem);
         display: flex;
+        flex-direction: column;
         justify-content: center;
         align-items: center;
     }
@@ -109,8 +110,6 @@ $body = $renderDynamicElements($body);
     .popup-menuppal__content {
         width: 100%;
         max-width: 1100px;
-        max-height: 100%;
-        overflow: auto;
         font-family: "Roboto Condensed", "Roboto", sans-serif;
         font-size: 2rem;
         line-height: 1.25;
@@ -121,7 +120,7 @@ $body = $renderDynamicElements($body);
         width: 100%;
         display: flex;
         justify-content: center;
-        margin-top: 1.25rem;
+        margin-top: 1.5rem;
     }
 
     .popup-menuppal__content table:not([border]):not([style*="border"]),
@@ -148,8 +147,8 @@ $body = $renderDynamicElements($body);
         background: #708090;
         color: #fff;
         font-family: "Bebas Neue", sans-serif;
-        font-size: 1.25rem;
-        padding: 0.35rem 0.75rem;
+        font-size: 1.6rem;
+        padding: 0.55rem 1.5rem;
         cursor: pointer;
     }
 

--- a/templates/Pagines/view.php
+++ b/templates/Pagines/view.php
@@ -77,15 +77,21 @@ $body = $renderDynamicElements($body);
 
     <style>
     .popup-menuppal {
-        position: fixed;
-        inset: 0;
-        z-index: 999999;
+        position: fixed !important;
+        top: 0 !important;
+        right: 0 !important;
+        bottom: 0 !important;
+        left: 0 !important;
+        width: 100vw;
+        height: 100vh;
+        z-index: 2147483647 !important;
         background: #e55381;
         color: #fff;
         display: flex;
         justify-content: center;
         align-items: center;
         padding: 2rem;
+        isolation: isolate;
     }
 
     .popup-menuppal__content {
@@ -134,43 +140,19 @@ $body = $renderDynamicElements($body);
 
     <script>
     (function () {
-        console.info('[menuppal-popup] init', {
-            isMenuPpalPage: true,
-            popupBodyLength: <?= json_encode(strlen($popupBody)) ?>
-        });
-
         const modal = document.getElementById('popupMenuppal');
         const closeBtn = document.getElementById('popupMenuppalClose');
         if (!modal || !closeBtn) {
-            console.warn('[menuppal-popup] modal o boto no trobats', {
-                modalFound: Boolean(modal),
-                closeBtnFound: Boolean(closeBtn)
-            });
             return;
         }
 
-        console.info('[menuppal-popup] modal visible');
+        if (modal.parentElement !== document.body) {
+            document.body.appendChild(modal);
+        }
 
         closeBtn.addEventListener('click', function () {
-            console.info('[menuppal-popup] tancat per usuari');
             modal.remove();
         });
-    })();
-    </script>
-<?php endif; ?>
-
-<?php if ($isMenuPpalPage): ?>
-    <script>
-    (function () {
-        console.info('[menuppal] pagina carregada', {
-            isMenuPpalPage: true,
-            popupPresent: <?= json_encode($popupBody !== '') ?>,
-            popupBodyLength: <?= json_encode(strlen($popupBody)) ?>
-        });
-
-        if (!<?= json_encode($popupBody !== '') ?>) {
-            console.warn('[menuppal] no hi ha cap pagina amb popup=1 o body buit');
-        }
     })();
     </script>
 <?php endif; ?>

--- a/templates/Pagines/view.php
+++ b/templates/Pagines/view.php
@@ -110,6 +110,9 @@ if ($body !== '') {
         const tables = document.querySelectorAll('.pagina-body table, .pagina-body-main table');
 
         tables.forEach((table) => {
+            const isElementTable = table.closest('.pagina-element') !== null;
+
+            table.classList.remove('pagina-table-managed');
             table.classList.remove('table-stack-mobile');
             table.classList.remove('table-mobile-scroll');
             table.classList.remove('table-stack-mobile--plain-rows');
@@ -118,6 +121,12 @@ if ($body !== '') {
             });
 
             unwrapScrollableTable(table);
+
+            if (isElementTable) {
+                return;
+            }
+
+            table.classList.add('pagina-table-managed');
 
             if (!MOBILE_QUERY.matches) {
                 return;

--- a/templates/Pagines/view.php
+++ b/templates/Pagines/view.php
@@ -49,3 +49,71 @@ if ($body !== '') {
     </div>
 
 </div>
+
+<script>
+(function () {
+    const MOBILE_QUERY = window.matchMedia('(max-width: 900px)');
+
+    function getHeaderLabels(table) {
+        const labels = [];
+        const headerCells = table.querySelectorAll('thead th');
+
+        if (headerCells.length > 0) {
+            headerCells.forEach((cell) => labels.push((cell.textContent || '').trim()));
+            return labels;
+        }
+
+        const firstRow = table.querySelector('tr');
+        if (!firstRow) {
+            return labels;
+        }
+
+        firstRow.querySelectorAll('th, td').forEach((cell) => {
+            labels.push((cell.textContent || '').trim());
+        });
+
+        return labels;
+    }
+
+    function applyResponsiveTables() {
+        const tables = document.querySelectorAll('.pagina-body table, .pagina-body-main table');
+
+        tables.forEach((table) => {
+            table.classList.remove('table-stack-mobile');
+            table.querySelectorAll('td, th').forEach((cell) => {
+                cell.removeAttribute('data-label');
+            });
+
+            if (!MOBILE_QUERY.matches) {
+                return;
+            }
+
+            const shouldStack = table.scrollWidth > table.clientWidth;
+            if (!shouldStack) {
+                return;
+            }
+
+            const labels = getHeaderLabels(table);
+            const rows = table.querySelectorAll('tr');
+            const hasThead = table.querySelector('thead') !== null;
+
+            rows.forEach((row, rowIndex) => {
+                if (!hasThead && rowIndex === 0) {
+                    return;
+                }
+
+                row.querySelectorAll('th, td').forEach((cell, index) => {
+                    const label = labels[index] || '';
+                    cell.setAttribute('data-label', label);
+                });
+            });
+
+            table.classList.add('table-stack-mobile');
+        });
+    }
+
+    window.addEventListener('resize', applyResponsiveTables);
+    window.addEventListener('load', applyResponsiveTables);
+    applyResponsiveTables();
+})();
+</script>

--- a/templates/element/cursos.php
+++ b/templates/element/cursos.php
@@ -714,6 +714,16 @@ foreach ($courses as $course) {
         const top = document.getElementById('cursos-top');
         if (top) {
             top.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+            if (window.matchMedia('(max-width: 900px)').matches) {
+                const topbar = document.getElementById('appTopbar');
+                const topbarHeight = topbar ? topbar.offsetHeight : 0;
+                window.scrollBy({
+                    top: -(topbarHeight + 8),
+                    left: 0,
+                    behavior: 'smooth'
+                });
+            }
         }
     }
 

--- a/templates/element/cursos.php
+++ b/templates/element/cursos.php
@@ -636,7 +636,7 @@ foreach ($courses as $course) {
     z-index: 8;
     background: #fff !important;
     padding: 0;
-    margin-bottom: 0.5rem;
+    margin-bottom: 1.1rem;
     width: 100%;
     max-width: 100%;
 }
@@ -653,7 +653,7 @@ foreach ($courses as $course) {
 }
 
 .cursos-course-page .pestanya .text {
-    margin-top: 0.5rem;
+    margin-top: 0;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/webroot/css/calendar.css
+++ b/webroot/css/calendar.css
@@ -114,7 +114,7 @@ body::after {
 
 /* Targeta mes = bloc de taula Google Docs */
 .month-card {
-  border: 2px solid #b2abbf;
+  border: 0;
   border-radius: 0;         /* Google Docs: cantonades rectes */
   overflow: hidden;
   background: #ffffff;
@@ -273,11 +273,6 @@ body::after {
   border-right: 1px solid #b2abbf !important;
 }
 
-/* mantenim la vora inferior del mes si és l'última fila */
-.month-card__table tbody tr:last-child > td.month-card__empty {
-  border-bottom: 1px solid #b2abbf !important;
-}
-
 /* =========================
    NOMÉS VORA EXTERIOR DEL MES
    ========================= */
@@ -333,11 +328,24 @@ body::after {
   transition: transform .2s ease, box-shadow .2s ease;
 }
 
+.app-main:not(.has-menuppal) .app-container .pagina-body-main a.annual-calendar__action-btn {
+  color: #fff !important;
+  text-decoration: none !important;
+}
+
 .annual-calendar__action-btn:hover,
 .annual-calendar__action-btn:focus {
+  background: #e83e8c;
+  border-color: #e83e8c;
   color: #fff;
   transform: scale(1.04);
   box-shadow: 0 10px 24px rgba(0, 0, 0, .2);
+}
+
+.app-main:not(.has-menuppal) .app-container .pagina-body-main a.annual-calendar__action-btn:hover,
+.app-main:not(.has-menuppal) .app-container .pagina-body-main a.annual-calendar__action-btn:focus {
+  color: #fff !important;
+  text-decoration: none !important;
 }
 
 @media (max-width: 1200px) {

--- a/webroot/css/calendar.css
+++ b/webroot/css/calendar.css
@@ -69,15 +69,18 @@ body::after {
 
 /* Curs (model: lletra “display” gris) */
 .annual-calendar__course {
+  width: 100%;
+  display: block;
+  background: #708090;
+  color: #ffffff;
+  padding: 0.75rem 1rem;
+  margin: 0 0 0.9rem 0;
   font-family: "Bebas Neue", "Roboto Condensed", Arial, sans-serif;
-  font-size: 28px;
+  font-size: 2rem;
   font-weight: 400;
-  color: #808080;
+  line-height: 1;
   letter-spacing: 0.02em;
-
-  /* treiem el teu border-left i padding perquè s’assembli més al model */
-  border: 0;
-  padding: 0;
+  text-transform: uppercase;
 }
 
 /* Llegenda */
@@ -327,13 +330,14 @@ body::after {
   text-decoration: none;
   font-weight: 700;
   border: 2px solid #e83e8c;
-  transition: background-color .2s ease, color .2s ease;
+  transition: transform .2s ease, box-shadow .2s ease;
 }
 
 .annual-calendar__action-btn:hover,
 .annual-calendar__action-btn:focus {
-  background: #fff;
-  color: #e83e8c;
+  color: #fff;
+  transform: scale(1.04);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, .2);
 }
 
 @media (max-width: 1200px) {

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -547,12 +547,53 @@ body{ margin: 0; }
 }
 
 @media (max-width: 900px){
-  .pagina-body table,
-  .pagina-body-main table {
+  .pagina-body table.table-stack-mobile,
+  .pagina-body-main table.table-stack-mobile {
+    width: 100% !important;
+    border-collapse: collapse;
+  }
+
+  .pagina-body table.table-stack-mobile thead,
+  .pagina-body-main table.table-stack-mobile thead {
+    display: none;
+  }
+
+  .pagina-body table.table-stack-mobile tr,
+  .pagina-body-main table.table-stack-mobile tr {
     display: block;
-    max-width: 100%;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+    margin-bottom: 1rem;
+    border: 1px solid #ddd;
+    background: #fff;
+  }
+
+  .pagina-body table.table-stack-mobile td,
+  .pagina-body table.table-stack-mobile th,
+  .pagina-body-main table.table-stack-mobile td,
+  .pagina-body-main table.table-stack-mobile th {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    width: 100%;
+    border: 0;
+    border-bottom: 1px solid #eee;
+    text-align: right;
+  }
+
+  .pagina-body table.table-stack-mobile td:last-child,
+  .pagina-body table.table-stack-mobile th:last-child,
+  .pagina-body-main table.table-stack-mobile td:last-child,
+  .pagina-body-main table.table-stack-mobile th:last-child {
+    border-bottom: 0;
+  }
+
+  .pagina-body table.table-stack-mobile td::before,
+  .pagina-body table.table-stack-mobile th::before,
+  .pagina-body-main table.table-stack-mobile td::before,
+  .pagina-body-main table.table-stack-mobile th::before {
+    content: attr(data-label);
+    font-weight: 700;
+    text-align: left;
+    color: #444;
   }
 }
 

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -549,34 +549,50 @@ body{ margin: 0; }
 @media (max-width: 900px){
   .pagina-body table.table-stack-mobile,
   .pagina-body-main table.table-stack-mobile {
+    display: block;
     width: 100% !important;
     border-collapse: collapse;
+    table-layout: fixed;
   }
 
   .pagina-body table.table-stack-mobile thead,
-  .pagina-body-main table.table-stack-mobile thead {
+  .pagina-body-main table.table-stack-mobile thead,
+  .pagina-body table.table-stack-mobile colgroup,
+  .pagina-body-main table.table-stack-mobile colgroup {
     display: none;
+  }
+
+  .pagina-body table.table-stack-mobile tbody,
+  .pagina-body-main table.table-stack-mobile tbody {
+    display: block;
   }
 
   .pagina-body table.table-stack-mobile tr,
   .pagina-body-main table.table-stack-mobile tr {
     display: block;
-    margin-bottom: 1rem;
+    margin-bottom: 0.9rem;
     border: 1px solid #ddd;
     background: #fff;
+  }
+
+  .pagina-body table.table-stack-mobile.table-stack-mobile--no-thead tr:first-child,
+  .pagina-body-main table.table-stack-mobile.table-stack-mobile--no-thead tr:first-child {
+    display: none;
   }
 
   .pagina-body table.table-stack-mobile td,
   .pagina-body table.table-stack-mobile th,
   .pagina-body-main table.table-stack-mobile td,
   .pagina-body-main table.table-stack-mobile th {
-    display: flex;
-    justify-content: space-between;
-    gap: 1rem;
+    display: block;
     width: 100%;
     border: 0;
     border-bottom: 1px solid #eee;
-    text-align: right;
+    text-align: left !important;
+    white-space: normal !important;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    padding: 0.55rem 0.75rem;
   }
 
   .pagina-body table.table-stack-mobile td:last-child,
@@ -591,9 +607,19 @@ body{ margin: 0; }
   .pagina-body-main table.table-stack-mobile td::before,
   .pagina-body-main table.table-stack-mobile th::before {
     content: attr(data-label);
+    display: block;
     font-weight: 700;
     text-align: left;
     color: #444;
+    margin-bottom: 0.2rem;
+  }
+
+  .pagina-body table.table-stack-mobile td[data-label='']::before,
+  .pagina-body table.table-stack-mobile th[data-label='']::before,
+  .pagina-body-main table.table-stack-mobile td[data-label='']::before,
+  .pagina-body-main table.table-stack-mobile th[data-label='']::before {
+    content: none;
+    display: none;
   }
 }
 

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -585,14 +585,9 @@ body{ margin: 0; }
   .pagina-body table.table-stack-mobile tr,
   .pagina-body-main table.table-stack-mobile tr {
     display: block;
-    margin-bottom: 0.9rem;
+    margin-bottom: 1rem;
     border: 1px solid #ddd;
     background: #fff;
-  }
-
-  .pagina-body table.table-stack-mobile.table-stack-mobile--no-thead tr:first-child,
-  .pagina-body-main table.table-stack-mobile.table-stack-mobile--no-thead tr:first-child {
-    display: none;
   }
 
   .pagina-body table.table-stack-mobile td,
@@ -633,6 +628,21 @@ body{ margin: 0; }
   .pagina-body table.table-stack-mobile th[data-label='']::before,
   .pagina-body-main table.table-stack-mobile td[data-label='']::before,
   .pagina-body-main table.table-stack-mobile th[data-label='']::before {
+    content: none;
+    display: none;
+  }
+
+  .pagina-body table.table-stack-mobile.table-stack-mobile--plain-rows td,
+  .pagina-body table.table-stack-mobile.table-stack-mobile--plain-rows th,
+  .pagina-body-main table.table-stack-mobile.table-stack-mobile--plain-rows td,
+  .pagina-body-main table.table-stack-mobile.table-stack-mobile--plain-rows th {
+    font-weight: 400;
+  }
+
+  .pagina-body table.table-stack-mobile.table-stack-mobile--plain-rows td::before,
+  .pagina-body table.table-stack-mobile.table-stack-mobile--plain-rows th::before,
+  .pagina-body-main table.table-stack-mobile.table-stack-mobile--plain-rows td::before,
+  .pagina-body-main table.table-stack-mobile.table-stack-mobile--plain-rows th::before {
     content: none;
     display: none;
   }

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -533,11 +533,26 @@ body{ margin: 0; }
 
   .app-bottombar__inner > section:nth-child(2),
   .app-bottombar__inner > section:nth-child(3){
-    text-align: right;
+    text-align: center;
   }
 
   .app-bottombar__col--right .bottombar-text{
-    justify-content: flex-end;
+    justify-content: center;
+  }
+
+  .app-bottombar__col--right .horarisatencio-table{
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+@media (max-width: 900px){
+  .pagina-body table,
+  .pagina-body-main table {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
   }
 }
 

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -547,6 +547,21 @@ body{ margin: 0; }
 }
 
 @media (max-width: 900px){
+  .pagina-body .table-mobile-scroll-wrap,
+  .pagina-body-main .table-mobile-scroll-wrap {
+    width: 100%;
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    margin-bottom: 0.9rem;
+  }
+
+  .pagina-body table.table-mobile-scroll,
+  .pagina-body-main table.table-mobile-scroll {
+    min-width: 640px;
+    width: 100%;
+  }
+
   .pagina-body table.table-stack-mobile,
   .pagina-body-main table.table-stack-mobile {
     display: block;

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -800,11 +800,11 @@ body{ margin: 0; }
 .app-main:not(.has-menuppal) .app-container .pagina-body-main h3{
   font-family: "Bebas Neue", sans-serif;
   color: #ffffff;
-  padding: 0.5rem 1rem;
-  margin: 0.75rem 0 2rem 0;
-  line-height: 1.05;
-
-  display: inline-block;   /* 👈 clau */
+  padding: 0.75rem 1rem;
+  margin: 0.75rem 0 0.9rem 0;
+  line-height: 1;
+  width: 100%;
+  display: block;
 }
 
 .app-main:not(.has-menuppal) .app-container .pagina-body-main h1{

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -612,6 +612,15 @@ body{ margin: 0; }
     border-bottom: 0;
   }
 
+  .pagina-body table.table-stack-mobile:not([border]):not([style*="border"]) tr,
+  .pagina-body-main table.table-stack-mobile:not([border]):not([style*="border"]) tr,
+  .pagina-body table.table-stack-mobile:not([border]):not([style*="border"]) td:not([style*="border"]),
+  .pagina-body table.table-stack-mobile:not([border]):not([style*="border"]) th:not([style*="border"]),
+  .pagina-body-main table.table-stack-mobile:not([border]):not([style*="border"]) td:not([style*="border"]),
+  .pagina-body-main table.table-stack-mobile:not([border]):not([style*="border"]) th:not([style*="border"]) {
+    border: 0 !important;
+  }
+
   .pagina-body table.table-stack-mobile td::before,
   .pagina-body table.table-stack-mobile th::before,
   .pagina-body-main table.table-stack-mobile td::before,
@@ -668,6 +677,19 @@ body{ margin: 0; }
 /* Paràgrafs */
 .app-main:not(.has-menuppal) .app-container .pagina-body-main p{
   margin: 0.3rem 0;
+}
+
+/* Taules de contingut: per defecte, sense vora si no està especificada */
+.pagina-body table:not([border]):not([style*="border"]),
+.pagina-body-main table:not([border]):not([style*="border"]) {
+  border: 0 !important;
+}
+
+.pagina-body table:not([border]):not([style*="border"]) td:not([style*="border"]),
+.pagina-body table:not([border]):not([style*="border"]) th:not([style*="border"]),
+.pagina-body-main table:not([border]):not([style*="border"]) td:not([style*="border"]),
+.pagina-body-main table:not([border]):not([style*="border"]) th:not([style*="border"]) {
+  border: 0 !important;
 }
 
 /* Links */

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -602,7 +602,13 @@ body{ margin: 0; }
     white-space: normal !important;
     overflow-wrap: anywhere;
     word-break: break-word;
-    padding: 0.55rem 0.75rem;
+  }
+
+  .pagina-body table.table-stack-mobile td:not([style*="padding"]),
+  .pagina-body table.table-stack-mobile th:not([style*="padding"]),
+  .pagina-body-main table.table-stack-mobile td:not([style*="padding"]),
+  .pagina-body-main table.table-stack-mobile th:not([style*="padding"]) {
+    padding: 2px 0;
   }
 
   .pagina-body table.table-stack-mobile td:last-child,
@@ -683,6 +689,13 @@ body{ margin: 0; }
 .pagina-body table:not([border]):not([style*="border"]),
 .pagina-body-main table:not([border]):not([style*="border"]) {
   border: 0 !important;
+}
+
+.pagina-body table td:not([style*="padding"]),
+.pagina-body table th:not([style*="padding"]),
+.pagina-body-main table td:not([style*="padding"]),
+.pagina-body-main table th:not([style*="padding"]) {
+  padding: 2px 0;
 }
 
 .pagina-body table:not([border]):not([style*="border"]) td:not([style*="border"]),

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -556,44 +556,44 @@ body{ margin: 0; }
     margin-bottom: 0.9rem;
   }
 
-  .pagina-body table.table-mobile-scroll,
-  .pagina-body-main table.table-mobile-scroll {
+  .pagina-body table.pagina-table-managed.table-mobile-scroll,
+  .pagina-body-main table.pagina-table-managed.table-mobile-scroll {
     min-width: 640px;
     width: 100%;
   }
 
-  .pagina-body table.table-stack-mobile,
-  .pagina-body-main table.table-stack-mobile {
+  .pagina-body table.pagina-table-managed.table-stack-mobile,
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile {
     display: block;
     width: 100% !important;
     border-collapse: collapse;
     table-layout: fixed;
   }
 
-  .pagina-body table.table-stack-mobile thead,
-  .pagina-body-main table.table-stack-mobile thead,
-  .pagina-body table.table-stack-mobile colgroup,
-  .pagina-body-main table.table-stack-mobile colgroup {
+  .pagina-body table.pagina-table-managed.table-stack-mobile thead,
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile thead,
+  .pagina-body table.pagina-table-managed.table-stack-mobile colgroup,
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile colgroup {
     display: none;
   }
 
-  .pagina-body table.table-stack-mobile tbody,
-  .pagina-body-main table.table-stack-mobile tbody {
+  .pagina-body table.pagina-table-managed.table-stack-mobile tbody,
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile tbody {
     display: block;
   }
 
-  .pagina-body table.table-stack-mobile tr,
-  .pagina-body-main table.table-stack-mobile tr {
+  .pagina-body table.pagina-table-managed.table-stack-mobile tr,
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile tr {
     display: block;
     margin-bottom: 1rem;
     border: 1px solid #ddd;
     background: #fff;
   }
 
-  .pagina-body table.table-stack-mobile td,
-  .pagina-body table.table-stack-mobile th,
-  .pagina-body-main table.table-stack-mobile td,
-  .pagina-body-main table.table-stack-mobile th {
+  .pagina-body table.pagina-table-managed.table-stack-mobile td,
+  .pagina-body table.pagina-table-managed.table-stack-mobile th,
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile td,
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile th {
     display: block;
     width: 100%;
     border: 0;
@@ -604,33 +604,33 @@ body{ margin: 0; }
     word-break: break-word;
   }
 
-  .pagina-body table.table-stack-mobile td:not([style*="padding"]),
-  .pagina-body table.table-stack-mobile th:not([style*="padding"]),
-  .pagina-body-main table.table-stack-mobile td:not([style*="padding"]),
-  .pagina-body-main table.table-stack-mobile th:not([style*="padding"]) {
+  .pagina-body table.pagina-table-managed.table-stack-mobile td:not([style*="padding"]),
+  .pagina-body table.pagina-table-managed.table-stack-mobile th:not([style*="padding"]),
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile td:not([style*="padding"]),
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile th:not([style*="padding"]) {
     padding: 2px 0;
   }
 
-  .pagina-body table.table-stack-mobile td:last-child,
-  .pagina-body table.table-stack-mobile th:last-child,
-  .pagina-body-main table.table-stack-mobile td:last-child,
-  .pagina-body-main table.table-stack-mobile th:last-child {
+  .pagina-body table.pagina-table-managed.table-stack-mobile td:last-child,
+  .pagina-body table.pagina-table-managed.table-stack-mobile th:last-child,
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile td:last-child,
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile th:last-child {
     border-bottom: 0;
   }
 
-  .pagina-body table.table-stack-mobile:not([border]):not([style*="border"]) tr,
-  .pagina-body-main table.table-stack-mobile:not([border]):not([style*="border"]) tr,
-  .pagina-body table.table-stack-mobile:not([border]):not([style*="border"]) td:not([style*="border"]),
-  .pagina-body table.table-stack-mobile:not([border]):not([style*="border"]) th:not([style*="border"]),
-  .pagina-body-main table.table-stack-mobile:not([border]):not([style*="border"]) td:not([style*="border"]),
-  .pagina-body-main table.table-stack-mobile:not([border]):not([style*="border"]) th:not([style*="border"]) {
+  .pagina-body table.pagina-table-managed.table-stack-mobile:not([border]):not([style*="border"]) tr,
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile:not([border]):not([style*="border"]) tr,
+  .pagina-body table.pagina-table-managed.table-stack-mobile:not([border]):not([style*="border"]) td:not([style*="border"]),
+  .pagina-body table.pagina-table-managed.table-stack-mobile:not([border]):not([style*="border"]) th:not([style*="border"]),
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile:not([border]):not([style*="border"]) td:not([style*="border"]),
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile:not([border]):not([style*="border"]) th:not([style*="border"]) {
     border: 0 !important;
   }
 
-  .pagina-body table.table-stack-mobile td::before,
-  .pagina-body table.table-stack-mobile th::before,
-  .pagina-body-main table.table-stack-mobile td::before,
-  .pagina-body-main table.table-stack-mobile th::before {
+  .pagina-body table.pagina-table-managed.table-stack-mobile td::before,
+  .pagina-body table.pagina-table-managed.table-stack-mobile th::before,
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile td::before,
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile th::before {
     content: attr(data-label);
     display: block;
     font-weight: 700;
@@ -639,25 +639,25 @@ body{ margin: 0; }
     margin-bottom: 0.2rem;
   }
 
-  .pagina-body table.table-stack-mobile td[data-label='']::before,
-  .pagina-body table.table-stack-mobile th[data-label='']::before,
-  .pagina-body-main table.table-stack-mobile td[data-label='']::before,
-  .pagina-body-main table.table-stack-mobile th[data-label='']::before {
+  .pagina-body table.pagina-table-managed.table-stack-mobile td[data-label='']::before,
+  .pagina-body table.pagina-table-managed.table-stack-mobile th[data-label='']::before,
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile td[data-label='']::before,
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile th[data-label='']::before {
     content: none;
     display: none;
   }
 
-  .pagina-body table.table-stack-mobile.table-stack-mobile--plain-rows td,
-  .pagina-body table.table-stack-mobile.table-stack-mobile--plain-rows th,
-  .pagina-body-main table.table-stack-mobile.table-stack-mobile--plain-rows td,
-  .pagina-body-main table.table-stack-mobile.table-stack-mobile--plain-rows th {
+  .pagina-body table.pagina-table-managed.table-stack-mobile.table-stack-mobile--plain-rows td,
+  .pagina-body table.pagina-table-managed.table-stack-mobile.table-stack-mobile--plain-rows th,
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile.table-stack-mobile--plain-rows td,
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile.table-stack-mobile--plain-rows th {
     font-weight: 400;
   }
 
-  .pagina-body table.table-stack-mobile.table-stack-mobile--plain-rows td::before,
-  .pagina-body table.table-stack-mobile.table-stack-mobile--plain-rows th::before,
-  .pagina-body-main table.table-stack-mobile.table-stack-mobile--plain-rows td::before,
-  .pagina-body-main table.table-stack-mobile.table-stack-mobile--plain-rows th::before {
+  .pagina-body table.pagina-table-managed.table-stack-mobile.table-stack-mobile--plain-rows td::before,
+  .pagina-body table.pagina-table-managed.table-stack-mobile.table-stack-mobile--plain-rows th::before,
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile.table-stack-mobile--plain-rows td::before,
+  .pagina-body-main table.pagina-table-managed.table-stack-mobile.table-stack-mobile--plain-rows th::before {
     content: none;
     display: none;
   }
@@ -686,22 +686,22 @@ body{ margin: 0; }
 }
 
 /* Taules de contingut: per defecte, sense vora si no està especificada */
-.pagina-body table:not([border]):not([style*="border"]),
-.pagina-body-main table:not([border]):not([style*="border"]) {
+.pagina-body table.pagina-table-managed:not([border]):not([style*="border"]),
+.pagina-body-main table.pagina-table-managed:not([border]):not([style*="border"]) {
   border: 0 !important;
 }
 
-.pagina-body table td:not([style*="padding"]),
-.pagina-body table th:not([style*="padding"]),
-.pagina-body-main table td:not([style*="padding"]),
-.pagina-body-main table th:not([style*="padding"]) {
+.pagina-body table.pagina-table-managed td:not([style*="padding"]),
+.pagina-body table.pagina-table-managed th:not([style*="padding"]),
+.pagina-body-main table.pagina-table-managed td:not([style*="padding"]),
+.pagina-body-main table.pagina-table-managed th:not([style*="padding"]) {
   padding: 2px 0;
 }
 
-.pagina-body table:not([border]):not([style*="border"]) td:not([style*="border"]),
-.pagina-body table:not([border]):not([style*="border"]) th:not([style*="border"]),
-.pagina-body-main table:not([border]):not([style*="border"]) td:not([style*="border"]),
-.pagina-body-main table:not([border]):not([style*="border"]) th:not([style*="border"]) {
+.pagina-body table.pagina-table-managed:not([border]):not([style*="border"]) td:not([style*="border"]),
+.pagina-body table.pagina-table-managed:not([border]):not([style*="border"]) th:not([style*="border"]),
+.pagina-body-main table.pagina-table-managed:not([border]):not([style*="border"]) td:not([style*="border"]),
+.pagina-body-main table.pagina-table-managed:not([border]):not([style*="border"]) th:not([style*="border"]) {
   border: 0 !important;
 }
 

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -691,11 +691,13 @@ body{ margin: 0; }
   border: 0 !important;
 }
 
-.pagina-body table.pagina-table-managed td:not([style*="padding"]),
-.pagina-body table.pagina-table-managed th:not([style*="padding"]),
-.pagina-body-main table.pagina-table-managed td:not([style*="padding"]),
-.pagina-body-main table.pagina-table-managed th:not([style*="padding"]) {
-  padding: 2px 0;
+@media (min-width: 901px) {
+  .pagina-body table.pagina-table-managed td:not([style*="padding"]),
+  .pagina-body table.pagina-table-managed th:not([style*="padding"]),
+  .pagina-body-main table.pagina-table-managed td:not([style*="padding"]),
+  .pagina-body-main table.pagina-table-managed th:not([style*="padding"]) {
+    padding: 0.4rem;
+  }
 }
 
 .pagina-body table.pagina-table-managed:not([border]):not([style*="border"]) td:not([style*="border"]),


### PR DESCRIPTION
### Motivation
- On small screens the course details in the `cursos` element were scrolled behind the fixed topbar instead of appearing just below it.
- In mobile layout the bottombar's `CONTACTE` and `HORARI D’ATENCIÓ` columns needed to be centered for better presentation.
- Tables included in pages under `Pagines/view` overflow the viewport on small screens and should be made responsive with horizontal scrolling.

### Description
- Adjusted `templates/element/cursos.php` to perform an additional `scrollBy` on small viewports (<=900px) after showing a course so the content is scrolled into view below the fixed topbar.
- Updated `webroot/css/layout_custom.css` to center the bottombar columns on small screens and center the `horarisatencio` table.
- Added an `@media (max-width: 900px)` rule to make `.pagina-body table` and `.pagina-body-main table` `display: block`, `max-width: 100%` and `overflow-x: auto` to enable horizontal scrolling on narrow viewports.

### Testing
- Ran `php -l templates/element/cursos.php` which returned no syntax errors.
- Attempted to run a local PHP server and capture a mobile screenshot with Playwright, but the app returned a 500 due to a `Cake\Chronos`/PHP compatibility error so visual verification was limited.
- Committed the changes and confirmed the two modified files are `templates/element/cursos.php` and `webroot/css/layout_custom.css`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a99651fc30832abe51b1bebf014abf)