### PR TITLE
Add support for **file** upload links in pagines view

### DIFF
--- a/templates/Pagines/view.php
+++ b/templates/Pagines/view.php
@@ -14,8 +14,8 @@ $renderDynamicElements = function (string $html): string {
         return $html;
     }
 
-    $html = preg_replace_callback('/\*\*([^*\r\n]+)\*\*/', function ($m) {
-        $fileName = trim($m[1]);
+    $buildUploadUrl = function (string $rawFileName): ?string {
+        $fileName = trim($rawFileName);
 
         if (
             $fileName === '' ||
@@ -23,10 +23,29 @@ $renderDynamicElements = function (string $html): string {
             str_contains($fileName, '/') ||
             str_contains($fileName, '\\')
         ) {
+            return null;
+        }
+
+        return $this->Url->build('/upload/' . rawurlencode($fileName));
+    };
+
+    $html = preg_replace_callback('/([\"\'])\*\*([^*\r\n]+)\*\*\1/', function ($m) use ($buildUploadUrl) {
+        $url = $buildUploadUrl($m[2]);
+
+        if ($url === null) {
             return $m[0];
         }
 
-        $url = $this->Url->build('/upload/' . rawurlencode($fileName));
+        return $m[1] . h($url) . $m[1];
+    }, $html) ?? $html;
+
+    $html = preg_replace_callback('/\*\*([^*\r\n]+)\*\*/', function ($m) use ($buildUploadUrl) {
+        $fileName = trim($m[1]);
+        $url = $buildUploadUrl($fileName);
+
+        if ($url === null) {
+            return $m[0];
+        }
 
         return sprintf('<a href="%s" target="_blank" rel="noopener">%s</a>', h($url), h($fileName));
     }, $html) ?? $html;

--- a/templates/Pagines/view.php
+++ b/templates/Pagines/view.php
@@ -26,7 +26,7 @@ $renderDynamicElements = function (string $html): string {
             return null;
         }
 
-        return $this->Url->build('/upload/' . rawurlencode($fileName));
+        return $this->Url->build('/uploads/' . rawurlencode($fileName));
     };
 
     $html = preg_replace_callback('/([\"\'])\*\*([^*\r\n]+)\*\*\1/', function ($m) use ($buildUploadUrl) {

--- a/templates/Pagines/view.php
+++ b/templates/Pagines/view.php
@@ -14,6 +14,23 @@ $renderDynamicElements = function (string $html): string {
         return $html;
     }
 
+    $html = preg_replace_callback('/\*\*([^*\r\n]+)\*\*/', function ($m) {
+        $fileName = trim($m[1]);
+
+        if (
+            $fileName === '' ||
+            str_contains($fileName, '..') ||
+            str_contains($fileName, '/') ||
+            str_contains($fileName, '\\')
+        ) {
+            return $m[0];
+        }
+
+        $url = $this->Url->build('/upload/' . rawurlencode($fileName));
+
+        return sprintf('<a href="%s" target="_blank" rel="noopener">%s</a>', h($url), h($fileName));
+    }, $html) ?? $html;
+
     $pattern = '/(?:\{|\&\#123;)\s*([a-zA-Z0-9_-]+)\s*(?:\}|\&\#125;)/';
 
     return preg_replace_callback($pattern, function ($m) {

--- a/templates/element/galeria.php
+++ b/templates/element/galeria.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Galeria automàtica d'imatges a partir de webroot/uploads/galeriaN.ext
+ * Ús: {galeria}
+ *
+ * @var \App\View\AppView $this
+ */
+
+declare(strict_types=1);
+
+$uploadsPath = ROOT . DS . 'webroot' . DS . 'uploads';
+$images = [];
+
+if (is_dir($uploadsPath)) {
+    $entries = scandir($uploadsPath) ?: [];
+
+    foreach ($entries as $entry) {
+        if (!preg_match('/^galeria(\d+)\.(jpe?g|png|gif|webp|avif)$/i', $entry, $matches)) {
+            continue;
+        }
+
+        $images[] = [
+            'file' => $entry,
+            'order' => (int)$matches[1],
+        ];
+    }
+}
+
+usort($images, function (array $a, array $b): int {
+    $orderCompare = $a['order'] <=> $b['order'];
+    if ($orderCompare !== 0) {
+        return $orderCompare;
+    }
+
+    return strnatcasecmp($a['file'], $b['file']);
+});
+
+$carouselId = 'galeria-carousel-' . str_replace('.', '', uniqid('', true));
+?>
+
+<?php if ($images !== []): ?>
+    <div id="<?= h($carouselId) ?>" class="galeria-carousel" aria-label="Galeria d'imatges del centre">
+        <?php foreach ($images as $index => $image): ?>
+            <?php $imageUrl = $this->Url->build('/uploads/' . rawurlencode($image['file'])); ?>
+            <img
+                src="<?= h($imageUrl) ?>"
+                alt="Imatge de la galeria <?= $index + 1 ?>"
+                class="galeria-carousel__image<?= $index === 0 ? ' is-active' : '' ?>"
+                loading="lazy"
+                decoding="async"
+            >
+        <?php endforeach; ?>
+    </div>
+
+    <style>
+    #<?= h($carouselId) ?> {
+        position: relative;
+        width: min(100%, 30rem);
+        height: min(30rem, 75vw);
+        max-width: 30rem;
+        max-height: 30rem;
+        margin: 0 auto;
+        overflow: hidden;
+    }
+
+    #<?= h($carouselId) ?> .galeria-carousel__image {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+        opacity: 0;
+        transition: opacity 800ms ease-in-out;
+        pointer-events: none;
+        background: transparent;
+    }
+
+    #<?= h($carouselId) ?> .galeria-carousel__image.is-active {
+        opacity: 1;
+    }
+    </style>
+
+    <script>
+    (function () {
+        const carousel = document.getElementById('<?= h($carouselId) ?>');
+        if (!carousel) {
+            return;
+        }
+
+        const images = Array.from(carousel.querySelectorAll('.galeria-carousel__image'));
+        if (images.length <= 1) {
+            return;
+        }
+
+        let currentIndex = 0;
+
+        window.setInterval(function () {
+            const nextIndex = (currentIndex + 1) % images.length;
+            images[currentIndex].classList.remove('is-active');
+            images[nextIndex].classList.add('is-active');
+            currentIndex = nextIndex;
+        }, 3000);
+    })();
+    </script>
+<?php endif; ?>


### PR DESCRIPTION
### Motivation
- Pages (`templates/Pagines/view.php`) should allow authors to reference uploaded files inline using a simple `**filename.ext**` placeholder and have it render as a public link to `/upload/filename.ext`.
- Keep existing dynamic `{element}` rendering intact while preventing directory-traversal or path-injection via filename placeholders.

### Description
- Added a `preg_replace_callback` that detects `**filename**` patterns and replaces them with a safe anchor pointing to `/upload/<filename>` in `templates/Pagines/view.php`.
- Implemented validation to skip replacements when the filename is empty or contains `..`, `/`, or `\` to avoid unintended path traversal.
- Built the destination URL with `rawurlencode` via `$this->Url->build()` and returned an anchor with `target="_blank" rel="noopener"` for safe external opening.
- Left the existing `{element}` rendering function unchanged and executed the new file-link replacement before element processing so both popups and main body are covered.

### Testing
- Ran `php -l templates/Pagines/view.php` which reported no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e64c133690832a8df5caf38def9c83)