### PR TITLE
Include dotted order_code entries and implement natural multi-part numeric sort for menuppal

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -55,7 +55,7 @@ return function (RouteBuilder $routes): void {
          * its action called 'display', and we pass a param to select the view file
          * to use (in this case, templates/Pages/home.php)...
          */
-        $builder->connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
+        $builder->connect('/', ['controller' => 'Pagines', 'action' => 'view', 1]);
 
         /*
          * ...and connect the rest of 'Pages' controller's URLs.

--- a/config/routes.php
+++ b/config/routes.php
@@ -55,7 +55,7 @@ return function (RouteBuilder $routes): void {
          * its action called 'display', and we pass a param to select the view file
          * to use (in this case, templates/Pages/home.php)...
          */
-        $builder->connect('/', ['controller' => 'Pagines', 'action' => 'view', 1]);
+        $builder->connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
 
         /*
          * ...and connect the rest of 'Pages' controller's URLs.

--- a/config/routes.php
+++ b/config/routes.php
@@ -64,15 +64,6 @@ return function (RouteBuilder $routes): void {
         $builder->connect('/calendar', ['controller' => 'Calendar', 'action' => 'index']);
         $builder->connect('/calendar/pdf-annual', ['controller' => 'Calendar', 'action' => 'pdfAnnual']);
         $builder->connect('/calendar/pdf-monthly', ['controller' => 'Calendar', 'action' => 'pdfMonthly']);
-        $builder->connect(
-            '/pagines/{id}',
-            ['controller' => 'Pagines', 'action' => 'view'],
-            [
-                'pass' => ['id'],
-                'id' => '.+',
-            ]
-        );
-
         /*
          * Connect catchall routes for all controllers.
          *

--- a/config/routes.php
+++ b/config/routes.php
@@ -64,6 +64,14 @@ return function (RouteBuilder $routes): void {
         $builder->connect('/calendar', ['controller' => 'Calendar', 'action' => 'index']);
         $builder->connect('/calendar/pdf-annual', ['controller' => 'Calendar', 'action' => 'pdfAnnual']);
         $builder->connect('/calendar/pdf-monthly', ['controller' => 'Calendar', 'action' => 'pdfMonthly']);
+        $builder->connect(
+            '/pagines/{id}',
+            ['controller' => 'Pagines', 'action' => 'view'],
+            [
+                'pass' => ['id'],
+                'id' => '.+',
+            ]
+        );
 
         /*
          * Connect catchall routes for all controllers.

--- a/src/Controller/HorarisController.php
+++ b/src/Controller/HorarisController.php
@@ -300,6 +300,19 @@ class HorarisController extends AppController
                     ];
                 }
             }
+            usort($finalRows, static function (array $a, array $b): int {
+                $courseCmp = strcasecmp((string)($a['course'] ?? ''), (string)($b['course'] ?? ''));
+                if ($courseCmp !== 0) {
+                    return $courseCmp;
+                }
+
+                $dayCmp = strcasecmp((string)($a['days'] ?? ''), (string)($b['days'] ?? ''));
+                if ($dayCmp !== 0) {
+                    return $dayCmp;
+                }
+
+                return strcasecmp((string)($a['hours'] ?? ''), (string)($b['hours'] ?? ''));
+            });
             $sections[$key]['rows'] = $finalRows;
         }
 

--- a/src/Controller/HorarisController.php
+++ b/src/Controller/HorarisController.php
@@ -1,0 +1,290 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Cake\Http\Exception\NotFoundException;
+use setasign\Fpdi\Fpdi;
+
+class HorarisController extends AppController
+{
+    public function pdf(): void
+    {
+        $data = $this->buildHorarisData();
+
+        $pdf = new Fpdi('P', 'mm', 'A4');
+        $pdf->SetAutoPageBreak(false);
+        $pdf->AddFont('BebasNeue', '', 'BebasNeue.php');
+        $pdf->AddFont('RobotoCondensed', '', 'RobotoCondensed-VariableFont_wght.php');
+        $pdf->AddFont('RobotoCondensed', 'B', 'RobotoCondensed-Bold.php');
+
+        $pdf->AddPage();
+        $this->drawHeader($pdf, $data['yearLabel']);
+
+        $x = 14.0;
+        $y = 34.0;
+        $wLeft = 56.0;
+        $wMid = 88.0;
+        $wRight = 36.0;
+        $rowH = 7.2;
+
+        foreach ($data['sections'] as $section) {
+            $rows = $section['rows'];
+            $rowsCount = count($rows);
+            if ($rowsCount === 0) {
+                continue;
+            }
+
+            $sectionHeight = 8.0 + ($rowsCount * $rowH) + 6.0;
+            if ($y + $sectionHeight > 270) {
+                $this->drawFooter($pdf);
+                $pdf->AddPage();
+                $this->drawHeader($pdf, $data['yearLabel']);
+                $y = 34.0;
+            }
+
+            $rgb = $section['rgb'];
+
+            $pdf->SetFillColor($rgb[0], $rgb[1], $rgb[2]);
+            $pdf->Rect($x + $wLeft + $wMid, $y, $wRight, 8.0, 'F');
+            $pdf->SetTextColor(255, 255, 255);
+            $pdf->SetFont('BebasNeue', '', 14);
+            $pdf->SetXY($x + $wLeft + $wMid, $y + 1.1);
+            $pdf->Cell($wRight, 6, 'AULA', 0, 0, 'C');
+
+            $tableY = $y + 8.0;
+            $tableH = $rowsCount * $rowH;
+
+            $pdf->SetDrawColor($rgb[0], $rgb[1], $rgb[2]);
+            $pdf->SetLineWidth(0.55);
+            $pdf->Rect($x, $tableY, $wLeft + $wMid + $wRight, $tableH, 'D');
+
+            foreach ($rows as $idx => $row) {
+                $rowY = $tableY + ($idx * $rowH);
+
+                $pdf->SetFillColor($rgb[0], $rgb[1], $rgb[2]);
+                $pdf->Rect($x, $rowY, $wLeft, $rowH, 'F');
+
+                $pdf->SetTextColor(255, 255, 255);
+                $pdf->SetFont('BebasNeue', '', 12.5);
+                $pdf->SetXY($x + 2, $rowY + 1.15);
+                $pdf->Cell($wLeft - 4, 5.5, $this->pdfText($row['course']), 0, 0, 'C');
+
+                $pdf->SetTextColor(55, 55, 55);
+                $pdf->SetFont('RobotoCondensed', '', 10.4);
+                $pdf->SetXY($x + $wLeft + 2.6, $rowY + 1.05);
+                $pdf->Cell(54, 5.4, $this->pdfText($row['days']), 0, 0, 'L');
+
+                $pdf->SetXY($x + $wLeft + 54, $rowY + 1.05);
+                $pdf->Cell($wMid - 56, 5.4, $this->pdfText($row['hours']), 0, 0, 'L');
+
+                $pdf->SetXY($x + $wLeft + $wMid + 2, $rowY + 1.05);
+                $pdf->Cell($wRight - 4, 5.4, $this->pdfText($row['aula']), 0, 0, 'C');
+
+                if ($idx < $rowsCount - 1) {
+                    $pdf->SetDrawColor(215, 215, 215);
+                    $pdf->SetLineWidth(0.2);
+                    $pdf->Line($x, $rowY + $rowH, $x + $wLeft + $wMid + $wRight, $rowY + $rowH);
+                }
+            }
+
+            $y = $tableY + $tableH + 6.0;
+        }
+
+        $this->drawFooter($pdf);
+        $filename = sprintf('horaris-%s.pdf', strtolower(str_replace(' ', '-', $data['yearLabel'])));
+        $content = $pdf->Output('S');
+        $this->response = $this->response
+            ->withType('pdf')
+            ->withHeader('Content-Disposition', 'attachment; filename="' . $filename . '"')
+            ->withStringBody($content);
+        $this->autoRender = false;
+    }
+
+    /**
+     * @return array{yearLabel:string,sections:array<int,array{name:string,rgb:array<int,int>,rows:array<int,array{course:string,days:string,hours:string,aula:string}>}>}
+     */
+    private function buildHorarisData(): array
+    {
+        $Years = $this->fetchTable('Years');
+        $year = $Years->find()->order(['Years.datafi' => 'DESC', 'Years.id' => 'DESC'])->first();
+        if (!$year) {
+            throw new NotFoundException(__('No year found for horaris.'));
+        }
+
+        $Courses = $this->fetchTable('Courses');
+        $courses = $Courses->find()
+            ->where([
+                'Courses.year_id' => (int)$year->id,
+                'Courses.microgrup' => 0,
+                'Courses.propi' => 1,
+            ])
+            ->contain(['Subjects', 'Aulas', 'Horaris' => ['Days']])
+            ->order(['Subjects.name' => 'ASC', 'Courses.name' => 'ASC'])
+            ->all()
+            ->toList();
+
+        $dayOrder = [
+            'dilluns' => 1,
+            'dimarts' => 2,
+            'dimecres' => 3,
+            'dijous' => 4,
+            'divendres' => 5,
+            'dissabte' => 6,
+            'diumenge' => 7,
+        ];
+
+        $colorBySubject = [
+            'preparació' => [164, 201, 117],
+            'català' => [132, 188, 192],
+            'castellà' => [171, 165, 186],
+            'anglès' => [118, 136, 156],
+            'competic' => [221, 79, 132],
+        ];
+
+        $sections = [];
+        foreach ($courses as $course) {
+            $subjectName = trim((string)($course->subject->name ?? __('Altres')));
+            if ($subjectName === '') {
+                $subjectName = (string)__('Altres');
+            }
+
+            $sectionKey = mb_strtolower($subjectName);
+            if (!isset($sections[$sectionKey])) {
+                $rgb = [132, 188, 192];
+                foreach ($colorBySubject as $needle => $color) {
+                    if (str_contains($sectionKey, $needle)) {
+                        $rgb = $color;
+                        break;
+                    }
+                }
+
+                $sections[$sectionKey] = [
+                    'name' => $subjectName,
+                    'rgb' => $rgb,
+                    'rows' => [],
+                ];
+            }
+
+            $horaris = (array)($course->horaris ?? []);
+            usort($horaris, static function ($a, $b) use ($dayOrder): int {
+                $nameA = mb_strtolower((string)($a->day->name ?? ''));
+                $nameB = mb_strtolower((string)($b->day->name ?? ''));
+                $oa = $dayOrder[$nameA] ?? 99;
+                $ob = $dayOrder[$nameB] ?? 99;
+                if ($oa !== $ob) {
+                    return $oa <=> $ob;
+                }
+                return strcmp((string)($a->horainici ?? ''), (string)($b->horainici ?? ''));
+            });
+
+            $days = [];
+            $ranges = [];
+            foreach ($horaris as $h) {
+                $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
+                if ($dayName !== '' && !in_array($dayName, $days, true)) {
+                    $days[] = $dayName;
+                }
+
+                $start = $this->formatHour($h->horainici ?? null);
+                $end = $this->formatHour($h->horafinal ?? null);
+                if ($start !== '' && $end !== '') {
+                    $range = $start . '-' . $end . 'h';
+                    if (!in_array($range, $ranges, true)) {
+                        $ranges[] = $range;
+                    }
+                }
+            }
+
+            $daysText = $this->joinDays($days);
+            $hoursText = implode(' / ', $ranges);
+
+            $sections[$sectionKey]['rows'][] = [
+                'course' => mb_strtoupper((string)$course->name),
+                'days' => $daysText,
+                'hours' => $hoursText,
+                'aula' => mb_strtolower((string)($course->aula->name ?? '')),
+            ];
+        }
+
+        $yearLabel = sprintf(
+            'HORARIS %d-%02d',
+            (int)$year->datainici->format('Y'),
+            ((int)$year->datafi->format('Y')) % 100
+        );
+
+        return [
+            'yearLabel' => $yearLabel,
+            'sections' => array_values($sections),
+        ];
+    }
+
+    /**
+     * @param array<int,string> $days
+     */
+    private function joinDays(array $days): string
+    {
+        $days = array_values(array_filter(array_map('trim', $days), static fn(string $d): bool => $d !== ''));
+        $count = count($days);
+        if ($count === 0) {
+            return '';
+        }
+        if ($count === 1) {
+            return $days[0];
+        }
+        if ($count === 2) {
+            return $days[0] . ' i ' . $days[1];
+        }
+
+        $last = array_pop($days);
+        return implode(', ', $days) . ' i ' . $last;
+    }
+
+    private function formatHour(mixed $value): string
+    {
+        if (empty($value)) {
+            return '';
+        }
+
+        $raw = (string)$value;
+        if (preg_match('/^(\d{2}:\d{2})/', $raw, $m)) {
+            return $m[1];
+        }
+
+        return substr($raw, 0, 5);
+    }
+
+    private function drawHeader(Fpdi $pdf, string $title): void
+    {
+        $logoPath = WWW_ROOT . 'img' . DS . 'logoGran.png';
+        if (is_file($logoPath)) {
+            $pdf->Image($logoPath, 14, 10, 40, 20);
+        }
+
+        $pdf->SetTextColor(70, 70, 70);
+        $pdf->SetFont('RobotoCondensed', '', 12);
+        $pdf->SetXY(0, 14);
+        $pdf->Cell(210, 8, $this->pdfText($title), 0, 0, 'C');
+    }
+
+    private function drawFooter(Fpdi $pdf): void
+    {
+        $palette = [
+            [132, 188, 192], [118, 136, 156], [171, 165, 186], [221, 79, 132],
+            [164, 201, 117], [250, 177, 0], [168, 168, 168], [202, 178, 162],
+        ];
+
+        $x = 92.0;
+        $y = 284.0;
+        foreach ($palette as $color) {
+            $pdf->SetFillColor($color[0], $color[1], $color[2]);
+            $pdf->Rect($x, $y, 6.0, 6.0, 'F');
+            $x += 6.8;
+        }
+    }
+
+    private function pdfText(string $text): string
+    {
+        return html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    }
+}

--- a/src/Controller/HorarisController.php
+++ b/src/Controller/HorarisController.php
@@ -78,14 +78,27 @@ class HorarisController extends AppController
                 $pdf->Rect($x, $rowY, $wLeft, $rowH * $span, 'F');
 
                 $pdf->SetTextColor(255, 255, 255);
-                $pdf->SetFont('BebasNeue', '', 12.5);
-                $textY = $rowY + (($rowH * $span - 5.5) / 2);
-                $pdf->SetXY($x + 2, $textY);
-                $pdf->Cell($wLeft - 4, 5.5, $this->pdfText($row['course']), 0, 0, 'L');
+                $pdf->SetFont('BebasNeue', '', 11.8);
+                $courseLineHeight = 4.5;
+                $courseAvailableHeight = ($rowH * $span) - 1.4;
+                $maxCourseLines = max(1, (int)floor($courseAvailableHeight / $courseLineHeight));
+                $courseLines = $this->splitPdfTextLines($pdf, (string)($row['course'] ?? ''), $wLeft - 4);
+                if (count($courseLines) > $maxCourseLines) {
+                    $courseLines = array_slice($courseLines, 0, $maxCourseLines);
+                    $lastLine = (string)array_pop($courseLines);
+                    $courseLines[] = rtrim($lastLine, " \t\n\r\0\x0B-") . '…';
+                }
+                $courseTextHeight = count($courseLines) * $courseLineHeight;
+                $courseTextY = $rowY + (($rowH * $span - $courseTextHeight) / 2);
+                foreach ($courseLines as $lineIdx => $courseLine) {
+                    $pdf->SetXY($x + 2, $courseTextY + ($lineIdx * $courseLineHeight));
+                    $pdf->Cell($wLeft - 4, $courseLineHeight, $this->pdfText($courseLine), 0, 0, 'L');
+                }
 
                 for ($line = 0; $line < $span; $line++) {
                     $lineRow = $rows[$idx + $line];
                     $lineY = $tableY + (($idx + $line) * $rowH);
+                    $pdf->Rect($x + $wLeft + $wMid, $lineY, $wRight, $rowH, 'D');
                     $pdf->SetTextColor(55, 55, 55);
                     $pdf->SetFont('RobotoCondensed', '', 10.4);
                     $pdf->SetXY($x + $wLeft + 2.6, $lineY + 1.05);
@@ -368,5 +381,33 @@ class HorarisController extends AppController
     {
         $decoded = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
         return iconv('UTF-8', 'windows-1252//TRANSLIT', $decoded) ?: utf8_decode($decoded);
+    }
+
+    /**
+     * @return array<int,string>
+     */
+    private function splitPdfTextLines(Fpdi $pdf, string $text, float $maxWidth): array
+    {
+        $words = preg_split('/\s+/u', trim($text)) ?: [];
+        if ($words === []) {
+            return [''];
+        }
+
+        $lines = [];
+        $current = '';
+        foreach ($words as $word) {
+            $candidate = $current === '' ? $word : ($current . ' ' . $word);
+            if ($current !== '' && $pdf->GetStringWidth($this->pdfText($candidate)) > $maxWidth) {
+                $lines[] = $current;
+                $current = $word;
+                continue;
+            }
+            $current = $candidate;
+        }
+        if ($current !== '') {
+            $lines[] = $current;
+        }
+
+        return $lines === [] ? [''] : $lines;
     }
 }

--- a/src/Controller/HorarisController.php
+++ b/src/Controller/HorarisController.php
@@ -140,6 +140,20 @@ class HorarisController extends AppController
         ];
 
         $sections = [];
+        $parentCourseIds = [];
+        foreach ($courses as $maybeParent) {
+            $courseId = (int)($maybeParent->id ?? 0);
+            if ($courseId <= 0) {
+                continue;
+            }
+            foreach ($courses as $candidateChild) {
+                if ((int)($candidateChild->parentcourse_id ?? 0) === $courseId) {
+                    $parentCourseIds[$courseId] = true;
+                    break;
+                }
+            }
+        }
+
         foreach ($courses as $course) {
             $subjectName = trim((string)($course->subject->name ?? __('Altres')));
             if ($subjectName === '') {
@@ -172,47 +186,85 @@ class HorarisController extends AppController
             $level = trim((string)($course->level ?? ''));
             $tornName = trim((string)($course->torn->name ?? ''));
             $trioKey = mb_strtolower($sectionKey . '|' . $level . '|' . $tornName);
-            $courseLabel = mb_strtoupper(trim($subjectName . ' ' . $level . ' - ' . $tornName));
+            $courseLabel = mb_strtoupper(trim((string)$course->name));
+            $courseLabel = preg_replace('/\\s*-\\s*C\\d+$/u', '', $courseLabel) ?? $courseLabel;
+            $courseLabel = preg_replace('/\\s*-\\s*\\d+$/u', '', $courseLabel) ?? $courseLabel;
+
+            $courseNameNormalized = mb_strtolower((string)($course->name ?? ''));
+            $looksLikeParentAccess = str_contains($courseNameNormalized, 'proves')
+                && str_contains($courseNameNormalized, 'grau')
+                && str_contains($courseNameNormalized, 'mitj');
+            $isParentCourse = isset($parentCourseIds[(int)($course->id ?? 0)]) || $looksLikeParentAccess;
 
             if (!isset($sections[$sectionKey]['rows'][$trioKey])) {
                 $sections[$sectionKey]['rows'][$trioKey] = [
                     'course' => $courseLabel,
-                    'days' => [],
-                    'ranges' => [],
-                    'aulas' => [],
+                    'entries' => [],
+                    'is_parent' => $isParentCourse,
                 ];
             }
 
-            foreach ($horaris as $h) {
-                $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
-                if ($dayName !== '' && !in_array($dayName, $sections[$sectionKey]['rows'][$trioKey]['days'], true)) {
-                    $sections[$sectionKey]['rows'][$trioKey]['days'][] = $dayName;
+            $entries = [];
+            if ($isParentCourse) {
+                foreach ($horaris as $h) {
+                    $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
+                    $start = $this->formatHour($h->horainici ?? null);
+                    $end = $this->formatHour($h->horafinal ?? null);
+                    if ($dayName === '' || $start === '' || $end === '') {
+                        continue;
+                    }
+                    $entries[] = [
+                        'days' => $dayName,
+                        'hours' => $start . '-' . $end . 'h',
+                        'aula' => mb_strtolower((string)($course->aula->name ?? '')),
+                    ];
                 }
-                $start = $this->formatHour($h->horainici ?? null);
-                $end = $this->formatHour($h->horafinal ?? null);
-                if ($start !== '' && $end !== '') {
-                    $range = $start . '-' . $end . 'h';
-                    if (!in_array($range, $sections[$sectionKey]['rows'][$trioKey]['ranges'], true)) {
-                        $sections[$sectionKey]['rows'][$trioKey]['ranges'][] = $range;
+            } else {
+                $days = [];
+                $ranges = [];
+                foreach ($horaris as $h) {
+                    $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
+                    if ($dayName !== '' && !in_array($dayName, $days, true)) {
+                        $days[] = $dayName;
+                    }
+                    $start = $this->formatHour($h->horainici ?? null);
+                    $end = $this->formatHour($h->horafinal ?? null);
+                    if ($start !== '' && $end !== '') {
+                        $range = $start . '-' . $end . 'h';
+                        if (!in_array($range, $ranges, true)) {
+                            $ranges[] = $range;
+                        }
                     }
                 }
+                $entries[] = [
+                    'days' => $this->joinDays($days),
+                    'hours' => implode(' / ', $ranges),
+                    'aula' => mb_strtolower((string)($course->aula->name ?? '')),
+                ];
             }
 
-            $aulaName = mb_strtolower((string)($course->aula->name ?? ''));
-            if ($aulaName !== '' && !in_array($aulaName, $sections[$sectionKey]['rows'][$trioKey]['aulas'], true)) {
-                $sections[$sectionKey]['rows'][$trioKey]['aulas'][] = $aulaName;
+            $merged = array_merge((array)$sections[$sectionKey]['rows'][$trioKey]['entries'], $entries);
+            $dedup = [];
+            foreach ($merged as $entry) {
+                $k = (($entry['days'] ?? '') . '|' . ($entry['hours'] ?? '') . '|' . ($entry['aula'] ?? ''));
+                $dedup[$k] = $entry;
             }
+            $sections[$sectionKey]['rows'][$trioKey]['entries'] = array_values($dedup);
+            $sections[$sectionKey]['rows'][$trioKey]['is_parent'] =
+                (bool)$sections[$sectionKey]['rows'][$trioKey]['is_parent'] || $isParentCourse;
         }
 
         foreach ($sections as $key => $section) {
             $finalRows = [];
             foreach ((array)$section['rows'] as $row) {
-                $finalRows[] = [
-                    'course' => (string)$row['course'],
-                    'days' => $this->joinDays((array)$row['days']),
-                    'hours' => implode(' / ', (array)$row['ranges']),
-                    'aula' => implode(' / ', (array)$row['aulas']),
-                ];
+                foreach ((array)$row['entries'] as $entry) {
+                    $finalRows[] = [
+                        'course' => (string)$row['course'],
+                        'days' => (string)($entry['days'] ?? ''),
+                        'hours' => (string)($entry['hours'] ?? ''),
+                        'aula' => (string)($entry['aula'] ?? ''),
+                    ];
+                }
             }
             $sections[$key]['rows'] = $finalRows;
         }

--- a/src/Controller/HorarisController.php
+++ b/src/Controller/HorarisController.php
@@ -59,28 +59,46 @@ class HorarisController extends AppController
             $pdf->SetLineWidth(0.55);
             $pdf->Rect($x, $tableY, $wLeft + $wMid + $wRight, $tableH, 'D');
 
-            foreach ($rows as $idx => $row) {
+            for ($idx = 0; $idx < $rowsCount; $idx++) {
+                $row = $rows[$idx];
                 $rowY = $tableY + ($idx * $rowH);
 
+                $span = 1;
+                if (!empty($row['is_parent'])) {
+                    for ($j = $idx + 1; $j < $rowsCount; $j++) {
+                        $next = $rows[$j];
+                        if (empty($next['is_parent']) || (string)($next['course'] ?? '') !== (string)($row['course'] ?? '')) {
+                            break;
+                        }
+                        $span++;
+                    }
+                }
+
                 $pdf->SetFillColor($rgb[0], $rgb[1], $rgb[2]);
-                $pdf->Rect($x, $rowY, $wLeft, $rowH, 'F');
+                $pdf->Rect($x, $rowY, $wLeft, $rowH * $span, 'F');
 
                 $pdf->SetTextColor(255, 255, 255);
                 $pdf->SetFont('BebasNeue', '', 12.5);
-                $pdf->SetXY($x + 2, $rowY + 1.15);
+                $textY = $rowY + (($rowH * $span - 5.5) / 2);
+                $pdf->SetXY($x + 2, $textY);
                 $pdf->Cell($wLeft - 4, 5.5, $this->pdfText($row['course']), 0, 0, 'L');
 
-                $pdf->SetTextColor(55, 55, 55);
-                $pdf->SetFont('RobotoCondensed', '', 10.4);
-                $pdf->SetXY($x + $wLeft + 2.6, $rowY + 1.05);
-                $pdf->Cell(54, 5.4, $this->pdfText($row['days']), 0, 0, 'L');
+                for ($line = 0; $line < $span; $line++) {
+                    $lineRow = $rows[$idx + $line];
+                    $lineY = $tableY + (($idx + $line) * $rowH);
+                    $pdf->SetTextColor(55, 55, 55);
+                    $pdf->SetFont('RobotoCondensed', '', 10.4);
+                    $pdf->SetXY($x + $wLeft + 2.6, $lineY + 1.05);
+                    $pdf->Cell(54, 5.4, $this->pdfText((string)($lineRow['days'] ?? '')), 0, 0, 'L');
 
-                $pdf->SetXY($x + $wLeft + 54, $rowY + 1.05);
-                $pdf->Cell($wMid - 56, 5.4, $this->pdfText($row['hours']), 0, 0, 'L');
+                    $pdf->SetXY($x + $wLeft + 54, $lineY + 1.05);
+                    $pdf->Cell($wMid - 56, 5.4, $this->pdfText((string)($lineRow['hours'] ?? '')), 0, 0, 'L');
 
-                $pdf->SetXY($x + $wLeft + $wMid + 2, $rowY + 1.05);
-                $pdf->Cell($wRight - 4, 5.4, $this->pdfText($row['aula']), 0, 0, 'C');
+                    $pdf->SetXY($x + $wLeft + $wMid + 2, $lineY + 1.05);
+                    $pdf->Cell($wRight - 4, 5.4, $this->pdfText((string)($lineRow['aula'] ?? '')), 0, 0, 'C');
+                }
 
+                $idx += ($span - 1);
             }
 
             $y = $tableY + $tableH + 6.0;
@@ -263,6 +281,7 @@ class HorarisController extends AppController
                         'days' => (string)($entry['days'] ?? ''),
                         'hours' => (string)($entry['hours'] ?? ''),
                         'aula' => (string)($entry['aula'] ?? ''),
+                        'is_parent' => (bool)($row['is_parent'] ?? false),
                     ];
                 }
             }

--- a/src/Controller/HorarisController.php
+++ b/src/Controller/HorarisController.php
@@ -218,10 +218,10 @@ class HorarisController extends AppController
 
             $level = trim((string)($course->level ?? ''));
             $tornName = trim((string)($course->torn->name ?? ''));
-            $trioKey = mb_strtolower($sectionKey . '|' . $level . '|' . $tornName);
             $courseLabel = mb_strtoupper(trim((string)$course->name));
             $courseLabel = preg_replace('/\\s*-\\s*C\\d+$/u', '', $courseLabel) ?? $courseLabel;
             $courseLabel = preg_replace('/\\s*-\\s*\\d+$/u', '', $courseLabel) ?? $courseLabel;
+            $trioKey = mb_strtolower($sectionKey . '|' . $courseLabel . '|' . $level . '|' . $tornName);
 
             $courseNameNormalized = mb_strtolower((string)($course->name ?? ''));
             $looksLikeParentAccess = str_contains($courseNameNormalized, 'proves')

--- a/src/Controller/HorarisController.php
+++ b/src/Controller/HorarisController.php
@@ -68,7 +68,7 @@ class HorarisController extends AppController
                 $pdf->SetTextColor(255, 255, 255);
                 $pdf->SetFont('BebasNeue', '', 12.5);
                 $pdf->SetXY($x + 2, $rowY + 1.15);
-                $pdf->Cell($wLeft - 4, 5.5, $this->pdfText($row['course']), 0, 0, 'C');
+                $pdf->Cell($wLeft - 4, 5.5, $this->pdfText($row['course']), 0, 0, 'L');
 
                 $pdf->SetTextColor(55, 55, 55);
                 $pdf->SetFont('RobotoCondensed', '', 10.4);
@@ -81,11 +81,6 @@ class HorarisController extends AppController
                 $pdf->SetXY($x + $wLeft + $wMid + 2, $rowY + 1.05);
                 $pdf->Cell($wRight - 4, 5.4, $this->pdfText($row['aula']), 0, 0, 'C');
 
-                if ($idx < $rowsCount - 1) {
-                    $pdf->SetDrawColor(215, 215, 215);
-                    $pdf->SetLineWidth(0.2);
-                    $pdf->Line($x, $rowY + $rowH, $x + $wLeft + $wMid + $wRight, $rowY + $rowH);
-                }
             }
 
             $y = $tableY + $tableH + 6.0;
@@ -141,6 +136,10 @@ class HorarisController extends AppController
             'anglès' => [118, 136, 156],
             'competic' => [221, 79, 132],
         ];
+        $fallbackPalette = [
+            [132, 188, 192], [118, 136, 156], [171, 165, 186],
+            [221, 79, 132], [164, 201, 117], [250, 177, 0],
+        ];
 
         $sections = [];
         foreach ($courses as $course) {
@@ -151,7 +150,7 @@ class HorarisController extends AppController
 
             $sectionKey = mb_strtolower($subjectName);
             if (!isset($sections[$sectionKey])) {
-                $rgb = [132, 188, 192];
+                $rgb = $fallbackPalette[count($sections) % count($fallbackPalette)];
                 foreach ($colorBySubject as $needle => $color) {
                     if (str_contains($sectionKey, $needle)) {
                         $rgb = $color;
@@ -178,33 +177,73 @@ class HorarisController extends AppController
                 return strcmp((string)($a->horainici ?? ''), (string)($b->horainici ?? ''));
             });
 
-            $days = [];
-            $ranges = [];
-            foreach ($horaris as $h) {
-                $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
-                if ($dayName !== '' && !in_array($dayName, $days, true)) {
-                    $days[] = $dayName;
-                }
+            $courseNameNormalized = mb_strtolower((string)($course->name ?? ''));
+            $looksLikeParentAccess = str_contains($courseNameNormalized, 'proves')
+                && str_contains($courseNameNormalized, 'grau')
+                && str_contains($courseNameNormalized, 'mitj');
 
-                $start = $this->formatHour($h->horainici ?? null);
-                $end = $this->formatHour($h->horafinal ?? null);
-                if ($start !== '' && $end !== '') {
-                    $range = $start . '-' . $end . 'h';
-                    if (!in_array($range, $ranges, true)) {
-                        $ranges[] = $range;
-                    }
+            $isParentCourse = false;
+            foreach ($courses as $candidateChild) {
+                if ((int)($candidateChild->parentcourse_id ?? 0) === (int)($course->id ?? 0)) {
+                    $isParentCourse = true;
+                    break;
                 }
             }
+            $isParentCourse = $isParentCourse || $looksLikeParentAccess;
 
-            $daysText = $this->joinDays($days);
-            $hoursText = implode(' / ', $ranges);
+            $courseLabel = mb_strtoupper((string)$course->name);
+            if (preg_match('/^COMPETIC\\s*3\\s*-\\s*VESPRE\\s*-\\s*C\\d+$/u', $courseLabel)) {
+                $courseLabel = 'COMPETIC 3 - VESPRE';
+            }
 
-            $sections[$sectionKey]['rows'][] = [
-                'course' => mb_strtoupper((string)$course->name),
-                'days' => $daysText,
-                'hours' => $hoursText,
-                'aula' => mb_strtolower((string)($course->aula->name ?? '')),
-            ];
+            $entries = [];
+            if ($isParentCourse) {
+                foreach ($horaris as $h) {
+                    $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
+                    $start = $this->formatHour($h->horainici ?? null);
+                    $end = $this->formatHour($h->horafinal ?? null);
+                    if ($dayName === '' || $start === '' || $end === '') {
+                        continue;
+                    }
+                    $entries[] = [
+                        'course' => $courseLabel,
+                        'days' => $dayName,
+                        'hours' => $start . '-' . $end . 'h',
+                        'aula' => mb_strtolower((string)($course->aula->name ?? '')),
+                    ];
+                }
+            } else {
+                $days = [];
+                $ranges = [];
+                foreach ($horaris as $h) {
+                    $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
+                    if ($dayName !== '' && !in_array($dayName, $days, true)) {
+                        $days[] = $dayName;
+                    }
+                    $start = $this->formatHour($h->horainici ?? null);
+                    $end = $this->formatHour($h->horafinal ?? null);
+                    if ($start !== '' && $end !== '') {
+                        $range = $start . '-' . $end . 'h';
+                        if (!in_array($range, $ranges, true)) {
+                            $ranges[] = $range;
+                        }
+                    }
+                }
+                $entries[] = [
+                    'course' => $courseLabel,
+                    'days' => $this->joinDays($days),
+                    'hours' => implode(' / ', $ranges),
+                    'aula' => mb_strtolower((string)($course->aula->name ?? '')),
+                ];
+            }
+
+            $rows = (array)$sections[$sectionKey]['rows'];
+            $dedup = [];
+            foreach (array_merge($rows, $entries) as $row) {
+                $k = (($row['course'] ?? '') . '|' . ($row['days'] ?? '') . '|' . ($row['hours'] ?? '') . '|' . ($row['aula'] ?? ''));
+                $dedup[$k] = $row;
+            }
+            $sections[$sectionKey]['rows'] = array_values($dedup);
         }
 
         $yearLabel = sprintf(
@@ -258,7 +297,7 @@ class HorarisController extends AppController
     {
         $logoPath = WWW_ROOT . 'img' . DS . 'logoGran.png';
         if (is_file($logoPath)) {
-            $pdf->Image($logoPath, 14, 10, 40, 20);
+            $pdf->Image($logoPath, 14, 10, 40, 0);
         }
 
         $pdf->SetTextColor(70, 70, 70);
@@ -285,6 +324,7 @@ class HorarisController extends AppController
 
     private function pdfText(string $text): string
     {
-        return html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $decoded = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        return iconv('UTF-8', 'windows-1252//TRANSLIT', $decoded) ?: utf8_decode($decoded);
     }
 }

--- a/src/Controller/HorarisController.php
+++ b/src/Controller/HorarisController.php
@@ -114,7 +114,7 @@ class HorarisController extends AppController
                 'Courses.microgrup' => 0,
                 'Courses.propi' => 1,
             ])
-            ->contain(['Subjects', 'Aulas', 'Horaris' => ['Days']])
+            ->contain(['Subjects', 'Torns', 'Aulas', 'Horaris' => ['Days']])
             ->order(['Subjects.name' => 'ASC', 'Courses.name' => 'ASC'])
             ->all()
             ->toList();
@@ -177,73 +177,52 @@ class HorarisController extends AppController
                 return strcmp((string)($a->horainici ?? ''), (string)($b->horainici ?? ''));
             });
 
-            $courseNameNormalized = mb_strtolower((string)($course->name ?? ''));
-            $looksLikeParentAccess = str_contains($courseNameNormalized, 'proves')
-                && str_contains($courseNameNormalized, 'grau')
-                && str_contains($courseNameNormalized, 'mitj');
+            $level = trim((string)($course->level ?? ''));
+            $tornName = trim((string)($course->torn->name ?? ''));
+            $trioKey = mb_strtolower($sectionKey . '|' . $level . '|' . $tornName);
+            $courseLabel = mb_strtoupper(trim($subjectName . ' ' . $level . ' - ' . $tornName));
 
-            $isParentCourse = false;
-            foreach ($courses as $candidateChild) {
-                if ((int)($candidateChild->parentcourse_id ?? 0) === (int)($course->id ?? 0)) {
-                    $isParentCourse = true;
-                    break;
-                }
-            }
-            $isParentCourse = $isParentCourse || $looksLikeParentAccess;
-
-            $courseLabel = mb_strtoupper((string)$course->name);
-            if (preg_match('/^COMPETIC\\s*3\\s*-\\s*VESPRE\\s*-\\s*C\\d+$/u', $courseLabel)) {
-                $courseLabel = 'COMPETIC 3 - VESPRE';
-            }
-
-            $entries = [];
-            if ($isParentCourse) {
-                foreach ($horaris as $h) {
-                    $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
-                    $start = $this->formatHour($h->horainici ?? null);
-                    $end = $this->formatHour($h->horafinal ?? null);
-                    if ($dayName === '' || $start === '' || $end === '') {
-                        continue;
-                    }
-                    $entries[] = [
-                        'course' => $courseLabel,
-                        'days' => $dayName,
-                        'hours' => $start . '-' . $end . 'h',
-                        'aula' => mb_strtolower((string)($course->aula->name ?? '')),
-                    ];
-                }
-            } else {
-                $days = [];
-                $ranges = [];
-                foreach ($horaris as $h) {
-                    $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
-                    if ($dayName !== '' && !in_array($dayName, $days, true)) {
-                        $days[] = $dayName;
-                    }
-                    $start = $this->formatHour($h->horainici ?? null);
-                    $end = $this->formatHour($h->horafinal ?? null);
-                    if ($start !== '' && $end !== '') {
-                        $range = $start . '-' . $end . 'h';
-                        if (!in_array($range, $ranges, true)) {
-                            $ranges[] = $range;
-                        }
-                    }
-                }
-                $entries[] = [
+            if (!isset($sections[$sectionKey]['rows'][$trioKey])) {
+                $sections[$sectionKey]['rows'][$trioKey] = [
                     'course' => $courseLabel,
-                    'days' => $this->joinDays($days),
-                    'hours' => implode(' / ', $ranges),
-                    'aula' => mb_strtolower((string)($course->aula->name ?? '')),
+                    'days' => [],
+                    'ranges' => [],
+                    'aulas' => [],
                 ];
             }
 
-            $rows = (array)$sections[$sectionKey]['rows'];
-            $dedup = [];
-            foreach (array_merge($rows, $entries) as $row) {
-                $k = (($row['course'] ?? '') . '|' . ($row['days'] ?? '') . '|' . ($row['hours'] ?? '') . '|' . ($row['aula'] ?? ''));
-                $dedup[$k] = $row;
+            foreach ($horaris as $h) {
+                $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
+                if ($dayName !== '' && !in_array($dayName, $sections[$sectionKey]['rows'][$trioKey]['days'], true)) {
+                    $sections[$sectionKey]['rows'][$trioKey]['days'][] = $dayName;
+                }
+                $start = $this->formatHour($h->horainici ?? null);
+                $end = $this->formatHour($h->horafinal ?? null);
+                if ($start !== '' && $end !== '') {
+                    $range = $start . '-' . $end . 'h';
+                    if (!in_array($range, $sections[$sectionKey]['rows'][$trioKey]['ranges'], true)) {
+                        $sections[$sectionKey]['rows'][$trioKey]['ranges'][] = $range;
+                    }
+                }
             }
-            $sections[$sectionKey]['rows'] = array_values($dedup);
+
+            $aulaName = mb_strtolower((string)($course->aula->name ?? ''));
+            if ($aulaName !== '' && !in_array($aulaName, $sections[$sectionKey]['rows'][$trioKey]['aulas'], true)) {
+                $sections[$sectionKey]['rows'][$trioKey]['aulas'][] = $aulaName;
+            }
+        }
+
+        foreach ($sections as $key => $section) {
+            $finalRows = [];
+            foreach ((array)$section['rows'] as $row) {
+                $finalRows[] = [
+                    'course' => (string)$row['course'],
+                    'days' => $this->joinDays((array)$row['days']),
+                    'hours' => implode(' / ', (array)$row['ranges']),
+                    'aula' => implode(' / ', (array)$row['aulas']),
+                ];
+            }
+            $sections[$key]['rows'] = $finalRows;
         }
 
         $yearLabel = sprintf(

--- a/src/Controller/HorarisController.php
+++ b/src/Controller/HorarisController.php
@@ -129,16 +129,14 @@ class HorarisController extends AppController
             'diumenge' => 7,
         ];
 
-        $colorBySubject = [
-            'preparació' => [164, 201, 117],
-            'català' => [132, 188, 192],
-            'castellà' => [171, 165, 186],
-            'anglès' => [118, 136, 156],
-            'competic' => [221, 79, 132],
-        ];
-        $fallbackPalette = [
-            [132, 188, 192], [118, 136, 156], [171, 165, 186],
-            [221, 79, 132], [164, 201, 117], [250, 177, 0],
+        $palette = [
+            [229, 83, 129],  // rosa
+            [112, 128, 144], // blaumari
+            [142, 195, 195], // blaucel
+            [174, 213, 129], // verd
+            [254, 178, 14],  // taronja
+            [171, 165, 186], // lila
+            [168, 168, 168], // gris
         ];
 
         $sections = [];
@@ -150,13 +148,7 @@ class HorarisController extends AppController
 
             $sectionKey = mb_strtolower($subjectName);
             if (!isset($sections[$sectionKey])) {
-                $rgb = $fallbackPalette[count($sections) % count($fallbackPalette)];
-                foreach ($colorBySubject as $needle => $color) {
-                    if (str_contains($sectionKey, $needle)) {
-                        $rgb = $color;
-                        break;
-                    }
-                }
+                $rgb = $palette[count($sections) % count($palette)];
 
                 $sections[$sectionKey] = [
                     'name' => $subjectName,

--- a/src/Controller/HorarisController.php
+++ b/src/Controller/HorarisController.php
@@ -47,6 +47,9 @@ class HorarisController extends AppController
 
             $pdf->SetFillColor($rgb[0], $rgb[1], $rgb[2]);
             $pdf->Rect($x + $wLeft + $wMid, $y, $wRight, 8.0, 'F');
+            $pdf->SetDrawColor($rgb[0], $rgb[1], $rgb[2]);
+            $pdf->SetLineWidth(0.55);
+            $pdf->Rect($x + $wLeft + $wMid, $y, $wRight, 8.0, 'D');
             $pdf->SetTextColor(255, 255, 255);
             $pdf->SetFont('BebasNeue', '', 14);
             $pdf->SetXY($x + $wLeft + $wMid, $y + 1.1);
@@ -98,7 +101,6 @@ class HorarisController extends AppController
                 for ($line = 0; $line < $span; $line++) {
                     $lineRow = $rows[$idx + $line];
                     $lineY = $tableY + (($idx + $line) * $rowH);
-                    $pdf->Rect($x + $wLeft + $wMid, $lineY, $wRight, $rowH, 'D');
                     $pdf->SetTextColor(55, 55, 55);
                     $pdf->SetFont('RobotoCondensed', '', 10.4);
                     $pdf->SetXY($x + $wLeft + 2.6, $lineY + 1.05);

--- a/templates/Pagines/add.php
+++ b/templates/Pagines/add.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
     <ul>
         <li><code>{telefon}</code>: <?= __('valor de Configs.valuetext on name = telefoncentre') ?></li>
         <li><code>{email}</code>: <?= __('valor de Configs.valuetext on name = mailcentre') ?></li>
+        <li><code>{contacte}</code>: <?= __('adreça + codi postal/city + email + telèfon del centre des de Configs') ?></li>
         <li><code>{contactevcf}</code>: <?= __('valor de Configs.valuetext on name = urlcontactevcf') ?></li>
         <li><code>{data_inici_preinscripcio}</code>: <?= __('data més gran del camp Years.datainicipreinscripcio (format català)') ?></li>
         <li><code>{data_fi_preinscripcio}</code>: <?= __('data més gran del camp Years.datafipreinscripcio (format català)') ?></li>

--- a/templates/Pagines/add.php
+++ b/templates/Pagines/add.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
         <li><code>{horaripreinscripcio}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicipreinscripcio i la data màxima de datafipreinscripcio, ambdós inclosos') ?></li>
         <li><code>{horarireclamacions}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicireclamacions i la data màxima de datafireclamacions, ambdós inclosos') ?></li>
         <li><code>{horarimatricula}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicimatricula i la data màxima de datafimatricula, ambdós inclosos') ?></li>
+        <li><code>{horarisatencio_centre}</code>: <?= __('duplicat de {horarisatencio} amb línies centrades a la pàgina') ?></li>
         <li><code>{horaris}</code>: <?= __('taula d\'horaris de cursos propis (microgrup=0, propi=1) de l\'any més recent + botó de descàrrega en PDF') ?></li>
     </ul>
 </div>

--- a/templates/Pagines/add.php
+++ b/templates/Pagines/add.php
@@ -24,5 +24,6 @@ declare(strict_types=1);
         <li><code>{horaripreinscripcio}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicipreinscripcio i la data màxima de datafipreinscripcio, ambdós inclosos') ?></li>
         <li><code>{horarireclamacions}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicireclamacions i la data màxima de datafireclamacions, ambdós inclosos') ?></li>
         <li><code>{horarimatricula}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicimatricula i la data màxima de datafimatricula, ambdós inclosos') ?></li>
+        <li><code>{horaris}</code>: <?= __('taula d\'horaris de cursos propis (microgrup=0, propi=1) de l\'any més recent + botó de descàrrega en PDF') ?></li>
     </ul>
 </div>

--- a/templates/Pagines/edit.php
+++ b/templates/Pagines/edit.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
     <ul>
         <li><code>{telefon}</code>: <?= __('valor de Configs.valuetext on name = telefoncentre') ?></li>
         <li><code>{email}</code>: <?= __('valor de Configs.valuetext on name = mailcentre') ?></li>
+        <li><code>{contacte}</code>: <?= __('adreça + codi postal/city + email + telèfon del centre des de Configs') ?></li>
         <li><code>{contactevcf}</code>: <?= __('valor de Configs.valuetext on name = urlcontactevcf') ?></li>
         <li><code>{data_inici_preinscripcio}</code>: <?= __('data més gran del camp Years.datainicipreinscripcio (format català)') ?></li>
         <li><code>{data_fi_preinscripcio}</code>: <?= __('data més gran del camp Years.datafipreinscripcio (format català)') ?></li>

--- a/templates/Pagines/edit.php
+++ b/templates/Pagines/edit.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
         <li><code>{horaripreinscripcio}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicipreinscripcio i la data màxima de datafipreinscripcio, ambdós inclosos') ?></li>
         <li><code>{horarireclamacions}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicireclamacions i la data màxima de datafireclamacions, ambdós inclosos') ?></li>
         <li><code>{horarimatricula}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicimatricula i la data màxima de datafimatricula, ambdós inclosos') ?></li>
+        <li><code>{horarisatencio_centre}</code>: <?= __('duplicat de {horarisatencio} amb línies centrades a la pàgina') ?></li>
         <li><code>{horaris}</code>: <?= __('taula d\'horaris de cursos propis (microgrup=0, propi=1) de l\'any més recent + botó de descàrrega en PDF') ?></li>
     </ul>
 </div>

--- a/templates/Pagines/edit.php
+++ b/templates/Pagines/edit.php
@@ -24,5 +24,6 @@ declare(strict_types=1);
         <li><code>{horaripreinscripcio}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicipreinscripcio i la data màxima de datafipreinscripcio, ambdós inclosos') ?></li>
         <li><code>{horarireclamacions}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicireclamacions i la data màxima de datafireclamacions, ambdós inclosos') ?></li>
         <li><code>{horarimatricula}</code>: <?= __('taula d\'horaris (com {horarisatencio}) pels dies entre la data màxima de datainicimatricula i la data màxima de datafimatricula, ambdós inclosos') ?></li>
+        <li><code>{horaris}</code>: <?= __('taula d\'horaris de cursos propis (microgrup=0, propi=1) de l\'any més recent + botó de descàrrega en PDF') ?></li>
     </ul>
 </div>

--- a/templates/element/contacte.php
+++ b/templates/element/contacte.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+$getFirstConfigValue = static function (array $keys): string {
+    foreach ($keys as $key) {
+        $value = trim(paginesGetConfigValue((string)$key));
+        if ($value !== '') {
+            return $value;
+        }
+    }
+
+    return '';
+};
+
+$address = $getFirstConfigValue(['adreca_centre', 'adrecacentre', 'adreca']);
+$postalCode = $getFirstConfigValue(['postalcodecentre', 'postalcode_centre', 'postalcode']);
+$cityName = $getFirstConfigValue(['citynamecentre', 'cityname_centre', 'cityname', 'poblacio', 'poblaciocentre']);
+$email = $getFirstConfigValue(['mailcentre', 'emailcentre', 'email']);
+$phone = $getFirstConfigValue(['telefoncentre', 'telefon_centre', 'telefon', 'telcentre']);
+
+$cityLine = trim(trim($postalCode . ' ' . $cityName));
+?>
+<div><?= h($address) ?></div>
+<div><?= h($cityLine) ?></div>
+<div><?= h($email) ?></div>
+<div><?= h($phone) ?></div>

--- a/templates/element/contacte.php
+++ b/templates/element/contacte.php
@@ -23,15 +23,17 @@ $phone = $getFirstConfigValue(['telefoncentre', 'telefon_centre', 'telefon', 'te
 $cityLine = trim(trim($postalCode . ' ' . $cityName));
 $phoneHref = preg_replace('/\s+/', '', $phone) ?? '';
 ?>
-<div><?= h($address) ?></div>
-<div><?= h($cityLine) ?></div>
-<div>
-    <?php if ($email !== ''): ?>
-        <a href="mailto:<?= h($email) ?>"><?= h($email) ?></a>
-    <?php endif; ?>
-</div>
-<div>
-    <?php if ($phone !== ''): ?>
-        <a href="tel:<?= h($phoneHref) ?>"><?= h($phone) ?></a>
-    <?php endif; ?>
+<div style="text-align:center;">
+    <div><?= h($address) ?></div>
+    <div><?= h($cityLine) ?></div>
+    <div>
+        <?php if ($email !== ''): ?>
+            <a href="mailto:<?= h($email) ?>"><?= h($email) ?></a>
+        <?php endif; ?>
+    </div>
+    <div>
+        <?php if ($phone !== ''): ?>
+            <a href="tel:<?= h($phoneHref) ?>"><?= h($phone) ?></a>
+        <?php endif; ?>
+    </div>
 </div>

--- a/templates/element/contacte.php
+++ b/templates/element/contacte.php
@@ -21,8 +21,17 @@ $email = $getFirstConfigValue(['mailcentre', 'emailcentre', 'email']);
 $phone = $getFirstConfigValue(['telefoncentre', 'telefon_centre', 'telefon', 'telcentre']);
 
 $cityLine = trim(trim($postalCode . ' ' . $cityName));
+$phoneHref = preg_replace('/\s+/', '', $phone) ?? '';
 ?>
 <div><?= h($address) ?></div>
 <div><?= h($cityLine) ?></div>
-<div><?= h($email) ?></div>
-<div><?= h($phone) ?></div>
+<div>
+    <?php if ($email !== ''): ?>
+        <a href="mailto:<?= h($email) ?>"><?= h($email) ?></a>
+    <?php endif; ?>
+</div>
+<div>
+    <?php if ($phone !== ''): ?>
+        <a href="tel:<?= h($phoneHref) ?>"><?= h($phone) ?></a>
+    <?php endif; ?>
+</div>

--- a/templates/element/horaris.php
+++ b/templates/element/horaris.php
@@ -225,7 +225,7 @@ $yearLabel = sprintf('Horaris %d-%02d', (int)$year->datainici->format('Y'), ((in
                     $rowspan = max(1, count($entries));
                     ?>
                     <?php foreach ($entries as $idx => $entry): ?>
-                        <tr>
+                        <tr class="<?= $isParent ? 'horaris-course-table__row--parent' : '' ?>">
                             <?php if (!$isParent || $idx === 0): ?>
                                 <th
                                     scope="row"

--- a/templates/element/horaris.php
+++ b/templates/element/horaris.php
@@ -24,7 +24,7 @@ $courses = $Courses->find()
         'Courses.microgrup' => 0,
         'Courses.propi' => 1,
     ])
-    ->contain(['Subjects', 'Aulas', 'Horaris' => ['Days']])
+    ->contain(['Subjects', 'Torns', 'Aulas', 'Horaris' => ['Days']])
     ->order(['Subjects.name' => 'ASC', 'Courses.name' => 'ASC'])
     ->all()
     ->toList();
@@ -67,16 +67,6 @@ $formatHour = static function ($value): string {
     return substr($raw, 0, 5);
 };
 
-$normalizeCourseName = static function (string $name): string {
-    $label = mb_strtoupper(trim($name));
-
-    if (preg_match('/^COMPETIC\\s*3\\s*-\\s*VESPRE\\s*-\\s*C\\d+$/u', $label)) {
-        return 'COMPETIC 3 - VESPRE';
-    }
-
-    return $label;
-};
-
 $colorBySubject = [
     'preparació' => '#A4C975',
     'català' => '#84BCC0',
@@ -87,19 +77,6 @@ $colorBySubject = [
 $fallbackPalette = ['#84BCC0', '#76889C', '#ABA5BA', '#DD4F84', '#A4C975', '#FAB100'];
 
 $sections = [];
-$parentCourseIds = [];
-foreach ($courses as $maybeParent) {
-    $courseId = (int)($maybeParent->id ?? 0);
-    if ($courseId <= 0) {
-        continue;
-    }
-    foreach ($courses as $candidateChild) {
-        if ((int)($candidateChild->parentcourse_id ?? 0) === $courseId) {
-            $parentCourseIds[$courseId] = true;
-            break;
-        }
-    }
-}
 
 foreach ($courses as $course) {
     $subjectName = trim((string)($course->subject->name ?? __('Altres')));
@@ -133,59 +110,14 @@ foreach ($courses as $course) {
         return strcmp((string)($a->horainici ?? ''), (string)($b->horainici ?? ''));
     });
 
-    $entries = [];
-    $courseNameNormalized = mb_strtolower((string)($course->name ?? ''));
-    $looksLikeParentAccess = str_contains($courseNameNormalized, 'proves')
-        && str_contains($courseNameNormalized, 'grau')
-        && str_contains($courseNameNormalized, 'mitj');
-    $isParentCourse = isset($parentCourseIds[(int)($course->id ?? 0)]) || $looksLikeParentAccess;
+    $level = trim((string)($course->level ?? ''));
+    $tornName = trim((string)($course->torn->name ?? ''));
+    $trioKey = mb_strtolower($sectionKey . '|' . $level . '|' . $tornName);
+    $label = mb_strtoupper(trim($subjectName . ' ' . $level . ' - ' . $tornName));
 
-    if ($isParentCourse) {
-        foreach ($horaris as $h) {
-            $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
-            $start = $formatHour($h->horainici ?? null);
-            $end = $formatHour($h->horafinal ?? null);
-
-            if ($dayName === '' || $start === '' || $end === '') {
-                continue;
-            }
-
-            $entries[] = [
-                'days' => $dayName,
-                'hours' => $start . '-' . $end . 'h',
-                'aula' => mb_strtolower((string)($course->aula->name ?? '')),
-            ];
-        }
-    } else {
-        $days = [];
-        $ranges = [];
-        foreach ($horaris as $h) {
-            $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
-            if ($dayName !== '' && !in_array($dayName, $days, true)) {
-                $days[] = $dayName;
-            }
-
-            $start = $formatHour($h->horainici ?? null);
-            $end = $formatHour($h->horafinal ?? null);
-            if ($start !== '' && $end !== '') {
-                $range = $start . '-' . $end . 'h';
-                if (!in_array($range, $ranges, true)) {
-                    $ranges[] = $range;
-                }
-            }
-        }
-
-        $entries[] = [
-            'days' => $joinDays($days),
-            'hours' => implode(' / ', $ranges),
-            'aula' => mb_strtolower((string)($course->aula->name ?? '')),
-        ];
-    }
-
-    $normalizedCourse = $normalizeCourseName((string)$course->name);
     $existingIdx = null;
     foreach ($sections[$sectionKey]['courses'] as $idx => $existing) {
-        if (($existing['course'] ?? '') === $normalizedCourse) {
+        if (($existing['trio_key'] ?? '') === $trioKey) {
             $existingIdx = $idx;
             break;
         }
@@ -193,23 +125,44 @@ foreach ($courses as $course) {
 
     if ($existingIdx === null) {
         $sections[$sectionKey]['courses'][] = [
-            'course' => $normalizedCourse,
-            'entries' => $entries,
-            'is_parent' => $isParentCourse,
+            'trio_key' => $trioKey,
+            'course' => $label,
+            'days' => [],
+            'ranges' => [],
+            'aulas' => [],
         ];
-    } else {
-        $mergedEntries = array_merge(
-            (array)$sections[$sectionKey]['courses'][$existingIdx]['entries'],
-            $entries
-        );
-        $dedup = [];
-        foreach ($mergedEntries as $entry) {
-            $entryKey = (($entry['days'] ?? '') . '|' . ($entry['hours'] ?? '') . '|' . ($entry['aula'] ?? ''));
-            $dedup[$entryKey] = $entry;
+        $existingIdx = count($sections[$sectionKey]['courses']) - 1;
+    }
+
+    foreach ($horaris as $h) {
+        $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
+        if ($dayName !== '' && !in_array($dayName, $sections[$sectionKey]['courses'][$existingIdx]['days'], true)) {
+            $sections[$sectionKey]['courses'][$existingIdx]['days'][] = $dayName;
         }
-        $sections[$sectionKey]['courses'][$existingIdx]['entries'] = array_values($dedup);
-        $sections[$sectionKey]['courses'][$existingIdx]['is_parent'] =
-            (bool)$sections[$sectionKey]['courses'][$existingIdx]['is_parent'] || $isParentCourse;
+
+        $start = $formatHour($h->horainici ?? null);
+        $end = $formatHour($h->horafinal ?? null);
+        if ($start !== '' && $end !== '') {
+            $range = $start . '-' . $end . 'h';
+            if (!in_array($range, $sections[$sectionKey]['courses'][$existingIdx]['ranges'], true)) {
+                $sections[$sectionKey]['courses'][$existingIdx]['ranges'][] = $range;
+            }
+        }
+    }
+
+    $aulaName = mb_strtolower((string)($course->aula->name ?? ''));
+    if ($aulaName !== '' && !in_array($aulaName, $sections[$sectionKey]['courses'][$existingIdx]['aulas'], true)) {
+        $sections[$sectionKey]['courses'][$existingIdx]['aulas'][] = $aulaName;
+    }
+}
+
+foreach ($sections as $sectionKey => $section) {
+    foreach ($section['courses'] as $idx => $courseRow) {
+        $sections[$sectionKey]['courses'][$idx]['entries'] = [[
+            'days' => $joinDays((array)$courseRow['days']),
+            'hours' => implode(' / ', (array)$courseRow['ranges']),
+            'aula' => implode(' / ', (array)$courseRow['aulas']),
+        ]];
     }
 }
 
@@ -230,20 +183,9 @@ $yearLabel = sprintf('Horaris %d-%02d', (int)$year->datainici->format('Y'), ((in
                 </thead>
                 <tbody>
                 <?php foreach ($section['courses'] as $courseBlock): ?>
-                    <?php
-                    $entries = (array)$courseBlock['entries'];
-                    $isParent = (bool)($courseBlock['is_parent'] ?? false);
-                    $rowspan = max(1, count($entries));
-                    ?>
-                    <?php foreach ($entries as $idx => $entry): ?>
+                    <?php foreach ((array)$courseBlock['entries'] as $entry): ?>
                         <tr>
-                            <?php if (!$isParent || $idx === 0): ?>
-                                <th
-                                    scope="row"
-                                    class="horaris-course-table__course"
-                                    <?= $isParent && $rowspan > 1 ? 'rowspan="' . (int)$rowspan . '"' : '' ?>
-                                ><?= h($courseBlock['course']) ?></th>
-                            <?php endif; ?>
+                            <th scope="row" class="horaris-course-table__course"><?= h($courseBlock['course']) ?></th>
                             <td class="horaris-course-table__days"><?= h($entry['days']) ?></td>
                             <td class="horaris-course-table__hours"><?= h($entry['hours']) ?></td>
                             <td class="horaris-course-table__aula"><?= h($entry['aula']) ?></td>

--- a/templates/element/horaris.php
+++ b/templates/element/horaris.php
@@ -179,17 +179,17 @@ $yearLabel = sprintf('Horaris %d-%02d', (int)$year->datainici->format('Y'), ((in
 <section class="horaris-board" aria-label="<?= h($yearLabel) ?>">
     <?php foreach (array_values($sections) as $section): ?>
         <div class="horaris-section" style="--section-color: <?= h($section['color']) ?>;" aria-label="<?= h($section['name']) ?>">
-            <?php foreach ($section['courses'] as $courseBlock): ?>
-                <table class="horaris-course-table" role="table">
-                    <thead>
-                        <tr>
-                            <th class="horaris-course-table__spacer"></th>
-                            <th class="horaris-course-table__spacer"></th>
-                            <th class="horaris-course-table__spacer"></th>
-                            <th class="horaris-course-table__aula-head">AULA</th>
-                        </tr>
-                    </thead>
-                    <tbody>
+            <table class="horaris-course-table" role="table">
+                <thead>
+                    <tr>
+                        <th class="horaris-course-table__spacer"></th>
+                        <th class="horaris-course-table__spacer"></th>
+                        <th class="horaris-course-table__spacer"></th>
+                        <th class="horaris-course-table__aula-head">AULA</th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($section['courses'] as $courseBlock): ?>
                     <?php foreach ($courseBlock['entries'] as $entry): ?>
                         <tr>
                             <th scope="row" class="horaris-course-table__course"><?= h($courseBlock['course']) ?></th>
@@ -198,9 +198,9 @@ $yearLabel = sprintf('Horaris %d-%02d', (int)$year->datainici->format('Y'), ((in
                             <td class="horaris-course-table__aula"><?= h($entry['aula']) ?></td>
                         </tr>
                     <?php endforeach; ?>
-                    </tbody>
-                </table>
-            <?php endforeach; ?>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
         </div>
     <?php endforeach; ?>
 

--- a/templates/element/horaris.php
+++ b/templates/element/horaris.php
@@ -67,14 +67,7 @@ $formatHour = static function ($value): string {
     return substr($raw, 0, 5);
 };
 
-$colorBySubject = [
-    'preparació' => '#A4C975',
-    'català' => '#84BCC0',
-    'castellà' => '#ABA5BA',
-    'anglès' => '#76889C',
-    'competic' => '#DD4F84',
-];
-$fallbackPalette = ['#84BCC0', '#76889C', '#ABA5BA', '#DD4F84', '#A4C975', '#FAB100'];
+$palette = ['#E55381', '#708090', '#8EC3C3', '#AED581', '#FEB20E', '#ABA5BA', '#A8A8A8'];
 
 $sections = [];
 
@@ -83,13 +76,7 @@ foreach ($courses as $course) {
     $sectionKey = mb_strtolower($subjectName !== '' ? $subjectName : (string)__('Altres'));
 
     if (!isset($sections[$sectionKey])) {
-        $color = $fallbackPalette[count($sections) % count($fallbackPalette)];
-        foreach ($colorBySubject as $needle => $value) {
-            if (str_contains($sectionKey, $needle)) {
-                $color = $value;
-                break;
-            }
-        }
+        $color = $palette[count($sections) % count($palette)];
 
         $sections[$sectionKey] = [
             'name' => $subjectName,

--- a/templates/element/horaris.php
+++ b/templates/element/horaris.php
@@ -76,6 +76,20 @@ $colorBySubject = [
 ];
 
 $sections = [];
+$parentCourseIds = [];
+foreach ($courses as $maybeParent) {
+    $courseId = (int)($maybeParent->id ?? 0);
+    if ($courseId <= 0) {
+        continue;
+    }
+    foreach ($courses as $candidateChild) {
+        if ((int)($candidateChild->parentcourse_id ?? 0) === $courseId) {
+            $parentCourseIds[$courseId] = true;
+            break;
+        }
+    }
+}
+
 foreach ($courses as $course) {
     $subjectName = trim((string)($course->subject->name ?? __('Altres')));
     $sectionKey = mb_strtolower($subjectName !== '' ? $subjectName : (string)__('Altres'));
@@ -92,7 +106,7 @@ foreach ($courses as $course) {
         $sections[$sectionKey] = [
             'name' => $subjectName,
             'color' => $color,
-            'rows' => [],
+            'courses' => [],
         ];
     }
 
@@ -108,29 +122,54 @@ foreach ($courses as $course) {
         return strcmp((string)($a->horainici ?? ''), (string)($b->horainici ?? ''));
     });
 
-    $days = [];
-    $ranges = [];
-    foreach ($horaris as $h) {
-        $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
-        if ($dayName !== '' && !in_array($dayName, $days, true)) {
-            $days[] = $dayName;
-        }
+    $entries = [];
+    $isParentCourse = isset($parentCourseIds[(int)($course->id ?? 0)]);
 
-        $start = $formatHour($h->horainici ?? null);
-        $end = $formatHour($h->horafinal ?? null);
-        if ($start !== '' && $end !== '') {
-            $range = $start . '-' . $end . 'h';
-            if (!in_array($range, $ranges, true)) {
-                $ranges[] = $range;
+    if ($isParentCourse) {
+        foreach ($horaris as $h) {
+            $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
+            $start = $formatHour($h->horainici ?? null);
+            $end = $formatHour($h->horafinal ?? null);
+
+            if ($dayName === '' || $start === '' || $end === '') {
+                continue;
+            }
+
+            $entries[] = [
+                'days' => $dayName,
+                'hours' => $start . '-' . $end . 'h',
+                'aula' => mb_strtolower((string)($course->aula->name ?? '')),
+            ];
+        }
+    } else {
+        $days = [];
+        $ranges = [];
+        foreach ($horaris as $h) {
+            $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
+            if ($dayName !== '' && !in_array($dayName, $days, true)) {
+                $days[] = $dayName;
+            }
+
+            $start = $formatHour($h->horainici ?? null);
+            $end = $formatHour($h->horafinal ?? null);
+            if ($start !== '' && $end !== '') {
+                $range = $start . '-' . $end . 'h';
+                if (!in_array($range, $ranges, true)) {
+                    $ranges[] = $range;
+                }
             }
         }
+
+        $entries[] = [
+            'days' => $joinDays($days),
+            'hours' => implode(' / ', $ranges),
+            'aula' => mb_strtolower((string)($course->aula->name ?? '')),
+        ];
     }
 
-    $sections[$sectionKey]['rows'][] = [
+    $sections[$sectionKey]['courses'][] = [
         'course' => mb_strtoupper((string)$course->name),
-        'days' => $joinDays($days),
-        'hours' => implode(' / ', $ranges),
-        'aula' => mb_strtolower((string)($course->aula->name ?? '')),
+        'entries' => $entries,
     ];
 }
 
@@ -138,6 +177,33 @@ $yearLabel = sprintf('Horaris %d-%02d', (int)$year->datainici->format('Y'), ((in
 ?>
 
 <section class="horaris-board" aria-label="<?= h($yearLabel) ?>">
+    <?php foreach (array_values($sections) as $section): ?>
+        <div class="horaris-section" style="--section-color: <?= h($section['color']) ?>;" aria-label="<?= h($section['name']) ?>">
+            <?php foreach ($section['courses'] as $courseBlock): ?>
+                <table class="horaris-course-table" role="table">
+                    <thead>
+                        <tr>
+                            <th class="horaris-course-table__spacer"></th>
+                            <th class="horaris-course-table__spacer"></th>
+                            <th class="horaris-course-table__spacer"></th>
+                            <th class="horaris-course-table__aula-head">AULA</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    <?php foreach ($courseBlock['entries'] as $entry): ?>
+                        <tr>
+                            <th scope="row" class="horaris-course-table__course"><?= h($courseBlock['course']) ?></th>
+                            <td class="horaris-course-table__days"><?= h($entry['days']) ?></td>
+                            <td class="horaris-course-table__hours"><?= h($entry['hours']) ?></td>
+                            <td class="horaris-course-table__aula"><?= h($entry['aula']) ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                    </tbody>
+                </table>
+            <?php endforeach; ?>
+        </div>
+    <?php endforeach; ?>
+
     <div class="horaris-board__actions">
         <?= $this->Html->link(
             __('Descarrega horaris (PDF)'),
@@ -145,23 +211,4 @@ $yearLabel = sprintf('Horaris %d-%02d', (int)$year->datainici->format('Y'), ((in
             ['class' => 'horaris-board__download-btn']
         ) ?>
     </div>
-
-    <?php foreach (array_values($sections) as $section): ?>
-        <div class="horaris-section" style="--section-color: <?= h($section['color']) ?>;">
-            <div class="horaris-section__header">AULA</div>
-
-            <table class="horaris-section__table" role="table">
-                <tbody>
-                <?php foreach ($section['rows'] as $row): ?>
-                    <tr>
-                        <th scope="row" class="horaris-section__course"><?= h($row['course']) ?></th>
-                        <td class="horaris-section__days"><?= h($row['days']) ?></td>
-                        <td class="horaris-section__hours"><?= h($row['hours']) ?></td>
-                        <td class="horaris-section__aula"><?= h($row['aula']) ?></td>
-                    </tr>
-                <?php endforeach; ?>
-                </tbody>
-            </table>
-        </div>
-    <?php endforeach; ?>
 </section>

--- a/templates/element/horaris.php
+++ b/templates/element/horaris.php
@@ -118,8 +118,8 @@ foreach ($courses as $course) {
 
     $level = trim((string)($course->level ?? ''));
     $tornName = trim((string)($course->torn->name ?? ''));
-    $trioKey = mb_strtolower($sectionKey . '|' . $level . '|' . $tornName);
     $label = $normalizeCourseLabel((string)$course->name);
+    $trioKey = mb_strtolower($sectionKey . '|' . $label . '|' . $level . '|' . $tornName);
     $courseNameNormalized = mb_strtolower((string)($course->name ?? ''));
     $looksLikeParentAccess = str_contains($courseNameNormalized, 'proves')
         && str_contains($courseNameNormalized, 'grau')

--- a/templates/element/horaris.php
+++ b/templates/element/horaris.php
@@ -74,6 +74,7 @@ $colorBySubject = [
     'anglès' => '#76889C',
     'competic' => '#DD4F84',
 ];
+$fallbackPalette = ['#84BCC0', '#76889C', '#ABA5BA', '#DD4F84', '#A4C975', '#FAB100'];
 
 $sections = [];
 $parentCourseIds = [];
@@ -95,7 +96,7 @@ foreach ($courses as $course) {
     $sectionKey = mb_strtolower($subjectName !== '' ? $subjectName : (string)__('Altres'));
 
     if (!isset($sections[$sectionKey])) {
-        $color = '#84BCC0';
+        $color = $fallbackPalette[count($sections) % count($fallbackPalette)];
         foreach ($colorBySubject as $needle => $value) {
             if (str_contains($sectionKey, $needle)) {
                 $color = $value;
@@ -123,7 +124,11 @@ foreach ($courses as $course) {
     });
 
     $entries = [];
-    $isParentCourse = isset($parentCourseIds[(int)($course->id ?? 0)]);
+    $courseNameNormalized = mb_strtolower((string)($course->name ?? ''));
+    $looksLikeParentAccess = str_contains($courseNameNormalized, 'proves')
+        && str_contains($courseNameNormalized, 'grau')
+        && str_contains($courseNameNormalized, 'mitj');
+    $isParentCourse = isset($parentCourseIds[(int)($course->id ?? 0)]) || $looksLikeParentAccess;
 
     if ($isParentCourse) {
         foreach ($horaris as $h) {

--- a/templates/element/horaris.php
+++ b/templates/element/horaris.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Element: horaris
+ *
+ * Horaris de cursos propis no microgrup de l'any més recent.
+ * Vista web: només taula d'horaris (sense logo, capçalera ni peu global).
+ */
+
+use Cake\Http\Exception\NotFoundException;
+use Cake\ORM\TableRegistry;
+
+$this->Html->css('horaris', ['block' => 'css']);
+
+$Years = TableRegistry::getTableLocator()->get('Years');
+$year = $Years->find()->order(['Years.datafi' => 'DESC', 'Years.id' => 'DESC'])->first();
+if (!$year) {
+    throw new NotFoundException(__('No year found for horaris.'));
+}
+
+$Courses = TableRegistry::getTableLocator()->get('Courses');
+$courses = $Courses->find()
+    ->where([
+        'Courses.year_id' => (int)$year->id,
+        'Courses.microgrup' => 0,
+        'Courses.propi' => 1,
+    ])
+    ->contain(['Subjects', 'Aulas', 'Horaris' => ['Days']])
+    ->order(['Subjects.name' => 'ASC', 'Courses.name' => 'ASC'])
+    ->all()
+    ->toList();
+
+$dayOrder = [
+    'dilluns' => 1,
+    'dimarts' => 2,
+    'dimecres' => 3,
+    'dijous' => 4,
+    'divendres' => 5,
+    'dissabte' => 6,
+    'diumenge' => 7,
+];
+
+$joinDays = static function (array $days): string {
+    $days = array_values(array_filter(array_map(static fn($d) => trim((string)$d), $days), static fn(string $d): bool => $d !== ''));
+    $count = count($days);
+    if ($count === 0) {
+        return '';
+    }
+    if ($count === 1) {
+        return $days[0];
+    }
+    if ($count === 2) {
+        return $days[0] . ' i ' . $days[1];
+    }
+
+    $last = array_pop($days);
+    return implode(', ', $days) . ' i ' . $last;
+};
+
+$formatHour = static function ($value): string {
+    if (empty($value)) {
+        return '';
+    }
+    $raw = (string)$value;
+    if (preg_match('/^(\d{2}:\d{2})/', $raw, $m)) {
+        return $m[1];
+    }
+    return substr($raw, 0, 5);
+};
+
+$colorBySubject = [
+    'preparació' => '#A4C975',
+    'català' => '#84BCC0',
+    'castellà' => '#ABA5BA',
+    'anglès' => '#76889C',
+    'competic' => '#DD4F84',
+];
+
+$sections = [];
+foreach ($courses as $course) {
+    $subjectName = trim((string)($course->subject->name ?? __('Altres')));
+    $sectionKey = mb_strtolower($subjectName !== '' ? $subjectName : (string)__('Altres'));
+
+    if (!isset($sections[$sectionKey])) {
+        $color = '#84BCC0';
+        foreach ($colorBySubject as $needle => $value) {
+            if (str_contains($sectionKey, $needle)) {
+                $color = $value;
+                break;
+            }
+        }
+
+        $sections[$sectionKey] = [
+            'name' => $subjectName,
+            'color' => $color,
+            'rows' => [],
+        ];
+    }
+
+    $horaris = (array)($course->horaris ?? []);
+    usort($horaris, static function ($a, $b) use ($dayOrder): int {
+        $nameA = mb_strtolower((string)($a->day->name ?? ''));
+        $nameB = mb_strtolower((string)($b->day->name ?? ''));
+        $oa = $dayOrder[$nameA] ?? 99;
+        $ob = $dayOrder[$nameB] ?? 99;
+        if ($oa !== $ob) {
+            return $oa <=> $ob;
+        }
+        return strcmp((string)($a->horainici ?? ''), (string)($b->horainici ?? ''));
+    });
+
+    $days = [];
+    $ranges = [];
+    foreach ($horaris as $h) {
+        $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
+        if ($dayName !== '' && !in_array($dayName, $days, true)) {
+            $days[] = $dayName;
+        }
+
+        $start = $formatHour($h->horainici ?? null);
+        $end = $formatHour($h->horafinal ?? null);
+        if ($start !== '' && $end !== '') {
+            $range = $start . '-' . $end . 'h';
+            if (!in_array($range, $ranges, true)) {
+                $ranges[] = $range;
+            }
+        }
+    }
+
+    $sections[$sectionKey]['rows'][] = [
+        'course' => mb_strtoupper((string)$course->name),
+        'days' => $joinDays($days),
+        'hours' => implode(' / ', $ranges),
+        'aula' => mb_strtolower((string)($course->aula->name ?? '')),
+    ];
+}
+
+$yearLabel = sprintf('Horaris %d-%02d', (int)$year->datainici->format('Y'), ((int)$year->datafi->format('Y')) % 100);
+?>
+
+<section class="horaris-board" aria-label="<?= h($yearLabel) ?>">
+    <div class="horaris-board__actions">
+        <?= $this->Html->link(
+            __('Descarrega horaris (PDF)'),
+            ['controller' => 'Horaris', 'action' => 'pdf'],
+            ['class' => 'horaris-board__download-btn']
+        ) ?>
+    </div>
+
+    <?php foreach (array_values($sections) as $section): ?>
+        <div class="horaris-section" style="--section-color: <?= h($section['color']) ?>;">
+            <div class="horaris-section__header">AULA</div>
+
+            <table class="horaris-section__table" role="table">
+                <tbody>
+                <?php foreach ($section['rows'] as $row): ?>
+                    <tr>
+                        <th scope="row" class="horaris-section__course"><?= h($row['course']) ?></th>
+                        <td class="horaris-section__days"><?= h($row['days']) ?></td>
+                        <td class="horaris-section__hours"><?= h($row['hours']) ?></td>
+                        <td class="horaris-section__aula"><?= h($row['aula']) ?></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    <?php endforeach; ?>
+</section>

--- a/templates/element/horaris.php
+++ b/templates/element/horaris.php
@@ -68,8 +68,27 @@ $formatHour = static function ($value): string {
 };
 
 $palette = ['#E55381', '#708090', '#8EC3C3', '#AED581', '#FEB20E', '#ABA5BA', '#A8A8A8'];
+$normalizeCourseLabel = static function (string $name): string {
+    $label = mb_strtoupper(trim($name));
+    $label = preg_replace('/\\s*-\\s*C\\d+$/u', '', $label) ?? $label;
+    $label = preg_replace('/\\s*-\\s*\\d+$/u', '', $label) ?? $label;
+    return trim($label);
+};
 
 $sections = [];
+$parentCourseIds = [];
+foreach ($courses as $maybeParent) {
+    $courseId = (int)($maybeParent->id ?? 0);
+    if ($courseId <= 0) {
+        continue;
+    }
+    foreach ($courses as $candidateChild) {
+        if ((int)($candidateChild->parentcourse_id ?? 0) === $courseId) {
+            $parentCourseIds[$courseId] = true;
+            break;
+        }
+    }
+}
 
 foreach ($courses as $course) {
     $subjectName = trim((string)($course->subject->name ?? __('Altres')));
@@ -100,7 +119,12 @@ foreach ($courses as $course) {
     $level = trim((string)($course->level ?? ''));
     $tornName = trim((string)($course->torn->name ?? ''));
     $trioKey = mb_strtolower($sectionKey . '|' . $level . '|' . $tornName);
-    $label = mb_strtoupper(trim($subjectName . ' ' . $level . ' - ' . $tornName));
+    $label = $normalizeCourseLabel((string)$course->name);
+    $courseNameNormalized = mb_strtolower((string)($course->name ?? ''));
+    $looksLikeParentAccess = str_contains($courseNameNormalized, 'proves')
+        && str_contains($courseNameNormalized, 'grau')
+        && str_contains($courseNameNormalized, 'mitj');
+    $isParentCourse = isset($parentCourseIds[(int)($course->id ?? 0)]) || $looksLikeParentAccess;
 
     $existingIdx = null;
     foreach ($sections[$sectionKey]['courses'] as $idx => $existing) {
@@ -114,43 +138,60 @@ foreach ($courses as $course) {
         $sections[$sectionKey]['courses'][] = [
             'trio_key' => $trioKey,
             'course' => $label,
-            'days' => [],
-            'ranges' => [],
-            'aulas' => [],
+            'entries' => [],
+            'is_parent' => $isParentCourse,
         ];
         $existingIdx = count($sections[$sectionKey]['courses']) - 1;
     }
 
-    foreach ($horaris as $h) {
-        $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
-        if ($dayName !== '' && !in_array($dayName, $sections[$sectionKey]['courses'][$existingIdx]['days'], true)) {
-            $sections[$sectionKey]['courses'][$existingIdx]['days'][] = $dayName;
+    $entries = [];
+    if ($isParentCourse) {
+        foreach ($horaris as $h) {
+            $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
+            $start = $formatHour($h->horainici ?? null);
+            $end = $formatHour($h->horafinal ?? null);
+            if ($dayName === '' || $start === '' || $end === '') {
+                continue;
+            }
+            $entries[] = [
+                'days' => $dayName,
+                'hours' => $start . '-' . $end . 'h',
+                'aula' => mb_strtolower((string)($course->aula->name ?? '')),
+            ];
         }
-
-        $start = $formatHour($h->horainici ?? null);
-        $end = $formatHour($h->horafinal ?? null);
-        if ($start !== '' && $end !== '') {
-            $range = $start . '-' . $end . 'h';
-            if (!in_array($range, $sections[$sectionKey]['courses'][$existingIdx]['ranges'], true)) {
-                $sections[$sectionKey]['courses'][$existingIdx]['ranges'][] = $range;
+    } else {
+        $days = [];
+        $ranges = [];
+        foreach ($horaris as $h) {
+            $dayName = mb_strtolower(trim((string)($h->day->name ?? '')));
+            if ($dayName !== '' && !in_array($dayName, $days, true)) {
+                $days[] = $dayName;
+            }
+            $start = $formatHour($h->horainici ?? null);
+            $end = $formatHour($h->horafinal ?? null);
+            if ($start !== '' && $end !== '') {
+                $range = $start . '-' . $end . 'h';
+                if (!in_array($range, $ranges, true)) {
+                    $ranges[] = $range;
+                }
             }
         }
+        $entries[] = [
+            'days' => $joinDays($days),
+            'hours' => implode(' / ', $ranges),
+            'aula' => mb_strtolower((string)($course->aula->name ?? '')),
+        ];
     }
 
-    $aulaName = mb_strtolower((string)($course->aula->name ?? ''));
-    if ($aulaName !== '' && !in_array($aulaName, $sections[$sectionKey]['courses'][$existingIdx]['aulas'], true)) {
-        $sections[$sectionKey]['courses'][$existingIdx]['aulas'][] = $aulaName;
+    $merged = array_merge((array)$sections[$sectionKey]['courses'][$existingIdx]['entries'], $entries);
+    $dedup = [];
+    foreach ($merged as $entry) {
+        $k = (($entry['days'] ?? '') . '|' . ($entry['hours'] ?? '') . '|' . ($entry['aula'] ?? ''));
+        $dedup[$k] = $entry;
     }
-}
-
-foreach ($sections as $sectionKey => $section) {
-    foreach ($section['courses'] as $idx => $courseRow) {
-        $sections[$sectionKey]['courses'][$idx]['entries'] = [[
-            'days' => $joinDays((array)$courseRow['days']),
-            'hours' => implode(' / ', (array)$courseRow['ranges']),
-            'aula' => implode(' / ', (array)$courseRow['aulas']),
-        ]];
-    }
+    $sections[$sectionKey]['courses'][$existingIdx]['entries'] = array_values($dedup);
+    $sections[$sectionKey]['courses'][$existingIdx]['is_parent'] =
+        (bool)$sections[$sectionKey]['courses'][$existingIdx]['is_parent'] || $isParentCourse;
 }
 
 $yearLabel = sprintf('Horaris %d-%02d', (int)$year->datainici->format('Y'), ((int)$year->datafi->format('Y')) % 100);
@@ -170,9 +211,20 @@ $yearLabel = sprintf('Horaris %d-%02d', (int)$year->datainici->format('Y'), ((in
                 </thead>
                 <tbody>
                 <?php foreach ($section['courses'] as $courseBlock): ?>
-                    <?php foreach ((array)$courseBlock['entries'] as $entry): ?>
+                    <?php
+                    $entries = (array)$courseBlock['entries'];
+                    $isParent = (bool)($courseBlock['is_parent'] ?? false);
+                    $rowspan = max(1, count($entries));
+                    ?>
+                    <?php foreach ($entries as $idx => $entry): ?>
                         <tr>
-                            <th scope="row" class="horaris-course-table__course"><?= h($courseBlock['course']) ?></th>
+                            <?php if (!$isParent || $idx === 0): ?>
+                                <th
+                                    scope="row"
+                                    class="horaris-course-table__course"
+                                    <?= $isParent && $rowspan > 1 ? 'rowspan="' . (int)$rowspan . '"' : '' ?>
+                                ><?= h($courseBlock['course']) ?></th>
+                            <?php endif; ?>
                             <td class="horaris-course-table__days"><?= h($entry['days']) ?></td>
                             <td class="horaris-course-table__hours"><?= h($entry['hours']) ?></td>
                             <td class="horaris-course-table__aula"><?= h($entry['aula']) ?></td>

--- a/templates/element/horaris.php
+++ b/templates/element/horaris.php
@@ -194,6 +194,14 @@ foreach ($courses as $course) {
         (bool)$sections[$sectionKey]['courses'][$existingIdx]['is_parent'] || $isParentCourse;
 }
 
+foreach ($sections as $sectionKey => $section) {
+    $sectionCourses = (array)($section['courses'] ?? []);
+    usort($sectionCourses, static function (array $a, array $b): int {
+        return strcasecmp((string)($a['course'] ?? ''), (string)($b['course'] ?? ''));
+    });
+    $sections[$sectionKey]['courses'] = $sectionCourses;
+}
+
 $yearLabel = sprintf('Horaris %d-%02d', (int)$year->datainici->format('Y'), ((int)$year->datafi->format('Y')) % 100);
 ?>
 

--- a/templates/element/horaris.php
+++ b/templates/element/horaris.php
@@ -67,6 +67,16 @@ $formatHour = static function ($value): string {
     return substr($raw, 0, 5);
 };
 
+$normalizeCourseName = static function (string $name): string {
+    $label = mb_strtoupper(trim($name));
+
+    if (preg_match('/^COMPETIC\\s*3\\s*-\\s*VESPRE\\s*-\\s*C\\d+$/u', $label)) {
+        return 'COMPETIC 3 - VESPRE';
+    }
+
+    return $label;
+};
+
 $colorBySubject = [
     'preparació' => '#A4C975',
     'català' => '#84BCC0',
@@ -172,11 +182,35 @@ foreach ($courses as $course) {
         ];
     }
 
-    $sections[$sectionKey]['courses'][] = [
-        'course' => mb_strtoupper((string)$course->name),
-        'entries' => $entries,
-        'is_parent' => $isParentCourse,
-    ];
+    $normalizedCourse = $normalizeCourseName((string)$course->name);
+    $existingIdx = null;
+    foreach ($sections[$sectionKey]['courses'] as $idx => $existing) {
+        if (($existing['course'] ?? '') === $normalizedCourse) {
+            $existingIdx = $idx;
+            break;
+        }
+    }
+
+    if ($existingIdx === null) {
+        $sections[$sectionKey]['courses'][] = [
+            'course' => $normalizedCourse,
+            'entries' => $entries,
+            'is_parent' => $isParentCourse,
+        ];
+    } else {
+        $mergedEntries = array_merge(
+            (array)$sections[$sectionKey]['courses'][$existingIdx]['entries'],
+            $entries
+        );
+        $dedup = [];
+        foreach ($mergedEntries as $entry) {
+            $entryKey = (($entry['days'] ?? '') . '|' . ($entry['hours'] ?? '') . '|' . ($entry['aula'] ?? ''));
+            $dedup[$entryKey] = $entry;
+        }
+        $sections[$sectionKey]['courses'][$existingIdx]['entries'] = array_values($dedup);
+        $sections[$sectionKey]['courses'][$existingIdx]['is_parent'] =
+            (bool)$sections[$sectionKey]['courses'][$existingIdx]['is_parent'] || $isParentCourse;
+    }
 }
 
 $yearLabel = sprintf('Horaris %d-%02d', (int)$year->datainici->format('Y'), ((int)$year->datafi->format('Y')) % 100);

--- a/templates/element/horaris.php
+++ b/templates/element/horaris.php
@@ -175,6 +175,7 @@ foreach ($courses as $course) {
     $sections[$sectionKey]['courses'][] = [
         'course' => mb_strtoupper((string)$course->name),
         'entries' => $entries,
+        'is_parent' => $isParentCourse,
     ];
 }
 
@@ -195,9 +196,20 @@ $yearLabel = sprintf('Horaris %d-%02d', (int)$year->datainici->format('Y'), ((in
                 </thead>
                 <tbody>
                 <?php foreach ($section['courses'] as $courseBlock): ?>
-                    <?php foreach ($courseBlock['entries'] as $entry): ?>
+                    <?php
+                    $entries = (array)$courseBlock['entries'];
+                    $isParent = (bool)($courseBlock['is_parent'] ?? false);
+                    $rowspan = max(1, count($entries));
+                    ?>
+                    <?php foreach ($entries as $idx => $entry): ?>
                         <tr>
-                            <th scope="row" class="horaris-course-table__course"><?= h($courseBlock['course']) ?></th>
+                            <?php if (!$isParent || $idx === 0): ?>
+                                <th
+                                    scope="row"
+                                    class="horaris-course-table__course"
+                                    <?= $isParent && $rowspan > 1 ? 'rowspan="' . (int)$rowspan . '"' : '' ?>
+                                ><?= h($courseBlock['course']) ?></th>
+                            <?php endif; ?>
                             <td class="horaris-course-table__days"><?= h($entry['days']) ?></td>
                             <td class="horaris-course-table__hours"><?= h($entry['hours']) ?></td>
                             <td class="horaris-course-table__aula"><?= h($entry['aula']) ?></td>

--- a/templates/element/horarisatencio_centre.php
+++ b/templates/element/horarisatencio_centre.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Element: horarisatencio_centre
+ *
+ * Mostra l'horari d'atenció d'avui i dels propers 7 dies (inclou avui = 8 dies),
+ * excloent dissabtes i diumenges.
+ *
+ * Requisits:
+ * - Taula sense vores, max-width: 10rem
+ * - Línies centrades a la pàgina
+ * - Dia + número del mes: "dimarts 26"
+ * - Si és specialdate per aquell dia: "dimarts* 26"
+ * - Si hi ha 2+ franges el mateix dia: "10:00-13:00 i 16:00-20:00"
+ * - Si un dia té specialdate, NO es mostren els recurrents (day_id) d'aquell dia
+ * - Si és laborable i no hi ha cap horari aplicable: "Tancat"
+ * - Separador setmanal: entre l'últim dia de la setmana (dg) i el primer (dl).
+ *   Com que no mostrem caps de setmana, es materialitza com una vora fina abans de cada dilluns (excepte el primer).
+ */
+
+use Cake\I18n\FrozenDate;
+use Cake\ORM\TableRegistry;
+
+require_once __DIR__ . '/_pagines_dynamic_utils.php';
+
+$daysCa = [
+    1 => 'dilluns',
+    2 => 'dimarts',
+    3 => 'dimecres',
+    4 => 'dijous',
+    5 => 'divendres',
+    6 => 'dissabte',
+    7 => 'diumenge',
+];
+
+// Rang (avui + 7 dies)
+$start = FrozenDate::today();
+$end   = $start->addDays(7);
+$festiusMap = paginesGetFestiuDateMap($start, $end);
+
+// Dates laborables del rang (dl..dv)
+$dates = [];
+for ($d = $start; $d <= $end; $d = $d->addDays(1)) {
+    $dow = (int)$d->format('N'); // 1..7 (dl..dg)
+    if ($dow === 6 || $dow === 7) continue; // exclou ds/dg
+    $dates[] = $d;
+}
+if (empty($dates)) {
+    return;
+}
+
+// Weekdays presents al rang (normalment 1..5)
+$weekdaysInRange = array_values(array_unique(array_map(fn($x) => (int)$x->format('N'), $dates)));
+
+$Horaris = TableRegistry::getTableLocator()->get('Horarisatencio');
+
+// Carreguem:
+// - Specialdates dins el rang
+// - Recurrents (specialdate null) pels weekdays del rang
+$rows = $Horaris->find()
+    ->contain(['Days'])
+    ->where([
+        'OR' => [
+            [
+                'Horarisatencio.specialdate >=' => $start,
+                'Horarisatencio.specialdate <=' => $end,
+            ],
+            [
+                'Horarisatencio.specialdate IS' => null,
+                'Horarisatencio.day_id IN' => $weekdaysInRange,
+            ],
+        ],
+    ])
+    ->order([
+        'Horarisatencio.specialdate' => 'ASC',
+        'Horarisatencio.day_id' => 'ASC',
+        'Horarisatencio.horainici' => 'ASC',
+        'Horarisatencio.horafinal' => 'ASC',
+    ])
+    ->all();
+
+// Estructura per data
+$itemsByDate = [];
+foreach ($dates as $d) {
+    $k = $d->format('Y-m-d');
+    $itemsByDate[$k] = [
+        'date' => $d,
+        'hasSpecial' => false,
+        'specialTimes' => [],
+        'regularTimes' => [],
+    ];
+}
+
+// Helper format hora 00:00
+$fmtTime = function ($t): string {
+    if (empty($t)) return '';
+    try {
+        return $t->i18nFormat('HH:mm');
+    } catch (\Throwable $e) {
+        return substr((string)$t, 0, 5);
+    }
+};
+
+// 1) Indexa primer els specialdate (i marca hasSpecial)
+foreach ($rows as $r) {
+    if (empty($r->specialdate)) continue;
+
+    $k = $r->specialdate->format('Y-m-d');
+    if (!isset($itemsByDate[$k])) continue;
+
+    $slot = trim($fmtTime($r->horainici) . '-' . $fmtTime($r->horafinal), '-');
+    if ($slot !== '' && $slot !== '-') {
+        $itemsByDate[$k]['specialTimes'][] = $slot;
+    }
+    $itemsByDate[$k]['hasSpecial'] = true; // encara que no hi hagi franja, anul·la recurrents
+}
+
+// 2) Aplica recurrents només als dies que NO tenen specialdate
+foreach ($rows as $r) {
+    if (!empty($r->specialdate)) continue;
+
+    $dayId = (int)($r->day_id ?? 0);
+    if ($dayId < 1 || $dayId > 7) continue;
+
+    $slot = trim($fmtTime($r->horainici) . '-' . $fmtTime($r->horafinal), '-');
+    if ($slot === '' || $slot === '-') continue;
+
+    foreach ($dates as $d) {
+        if ((int)$d->format('N') !== $dayId) continue;
+
+        $k = $d->format('Y-m-d');
+        if (!isset($itemsByDate[$k])) continue;
+
+        // Si hi ha specialdate aquell dia, NO mostrem recurrents
+        if ($itemsByDate[$k]['hasSpecial']) continue;
+
+        $itemsByDate[$k]['regularTimes'][] = $slot;
+    }
+}
+
+// Neteja: elimina duplicats i ordena
+foreach ($itemsByDate as $k => $info) {
+    $special = array_values(array_unique(array_filter($info['specialTimes'], fn($t) => $t !== '' && $t !== '-')));
+    $regular = array_values(array_unique(array_filter($info['regularTimes'], fn($t) => $t !== '' && $t !== '-')));
+
+    sort($special, SORT_NATURAL);
+    sort($regular, SORT_NATURAL);
+
+    $itemsByDate[$k]['specialTimes'] = $special;
+    $itemsByDate[$k]['regularTimes'] = $regular;
+}
+
+?>
+<table class="horarisatencio-table horarisatencio-table--centre" style="border-collapse:collapse; width:auto; margin:0 auto;">
+    <tbody>
+        <?php
+        $prevDate = null;
+
+        foreach ($itemsByDate as $k => $info):
+            /** @var \Cake\I18n\FrozenDate $d */
+            $d = $info['date'];
+            $dow = (int)$d->format('N'); // 1..7
+
+            // Separador setmanal: abans de cada dilluns (excepte el primer)
+            $isWeekSeparator = ($dow === 1 && $prevDate !== null);
+
+            $dayName = $daysCa[$dow] ?? strtolower($d->i18nFormat('EEEE'));
+            $asterisk = $info['hasSpecial'] ? '*' : '';
+            $dayLabel = $dayName . $asterisk . ' ' . $d->format('j');
+
+            // Si hi ha specialdate, només specialTimes. Si no, regularTimes.
+            $isFestiu = isset($festiusMap[$k]);
+            $times = $info['hasSpecial'] ? $info['specialTimes'] : $info['regularTimes'];
+
+            // Si no hi ha franges aplicables: dia laborable tancat
+            $timesText = $isFestiu ? __('Festiu') : (!empty($times) ? implode("\n", $times) : __('Tancat'));
+
+            $tdBase = 'padding:2px 0; border:none; vertical-align:top;';
+            $sepStyle = $isWeekSeparator ? 'border-top:1px solid rgba(0,0,0,0.2); padding-top:5px;' : '';
+        ?>
+            <tr>
+                <td style="<?= $tdBase ?> text-align:center; font-weight:700; padding-right:8px; <?= $sepStyle ?>">
+                    <?= h($dayLabel) ?>
+                </td>
+                <td style="<?= $tdBase ?> text-align:center; <?= $sepStyle ?>">
+                    <?= nl2br(h($timesText)) ?>
+                </td>
+            </tr>
+        <?php
+            $prevDate = $d;
+        endforeach;
+        ?>
+    </tbody>
+</table>

--- a/templates/element/horarisatencio_centre.php
+++ b/templates/element/horarisatencio_centre.php
@@ -178,7 +178,7 @@ foreach ($itemsByDate as $k => $info) {
             $sepStyle = $isWeekSeparator ? 'border-top:1px solid rgba(0,0,0,0.2); padding-top:5px;' : '';
         ?>
             <tr>
-                <td style="<?= $tdBase ?> text-align:center; font-weight:700; padding-right:8px; <?= $sepStyle ?>">
+                <td style="<?= $tdBase ?> text-align:right; font-weight:700; padding-right:8px; <?= $sepStyle ?>">
                     <?= h($dayLabel) ?>
                 </td>
                 <td style="<?= $tdBase ?> text-align:center; <?= $sepStyle ?>">

--- a/templates/element/menuppal.php
+++ b/templates/element/menuppal.php
@@ -91,13 +91,34 @@ $i = 0;
 .menuppal-wrapper{
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 3rem;
   justify-content: center;
 }
 
 /* 5 per fila màxim */
 .menuppal-wrapper > a.custom-button{
   flex: 0 0 20%;
+}
+
+/* Ajustos tipogràfics en pantalla gran */
+@media (min-width: 901px){
+  .custom-button .line1{
+    padding: 1rem;
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 1.8rem;
+    line-height: 3.5rem;
+    color: #fff;
+  }
+
+  .custom-button .line2{
+    padding-top: 1rem;
+    font-family: 'Roboto Condensed', sans-serif;
+    font-size: 1.2rem;
+    background: #f5f5f5;
+    color: #191919;
+    height: 4rem;
+    padding-bottom: 1rem;
+  }
 }
 
 /* =========================

--- a/templates/element/menuppal.php
+++ b/templates/element/menuppal.php
@@ -4,7 +4,6 @@
  *
  * - visible=1
  * - main=1
- * - principals (order_code sense punt)
  * - ordenació natural
  * - màxim 5 botons per fila
  * - espai sobrant repartit
@@ -20,19 +19,24 @@ $pages = $Pagines->find()
         'visible' => 1,
         'main' => 1,
     ])
-    ->andWhere(['order_code NOT LIKE' => '%.%'])
     ->all()
     ->toList();
 
 /* Ordenació natural */
 usort($pages, function ($a, $b) {
-    $va = (int)preg_replace('/\D+/', '', (string)$a->order_code);
-    $vb = (int)preg_replace('/\D+/', '', (string)$b->order_code);
+    $pa = array_map('intval', explode('.', (string)$a->order_code));
+    $pb = array_map('intval', explode('.', (string)$b->order_code));
 
-    if ($va === $vb) {
-        return strcmp((string)$a->order_code, (string)$b->order_code);
+    $len = max(count($pa), count($pb));
+    for ($idx = 0; $idx < $len; $idx++) {
+        $va = $pa[$idx] ?? 0;
+        $vb = $pb[$idx] ?? 0;
+        if ($va !== $vb) {
+            return $va <=> $vb;
+        }
     }
-    return $va <=> $vb;
+
+    return 0;
 });
 
 $colors = ['blaumari', 'blaucel', 'verd', 'rosa', 'lila', 'taronja', 'gris', 'ocre'];

--- a/templates/element/menuppal.php
+++ b/templates/element/menuppal.php
@@ -2,9 +2,9 @@
 /**
  * Element: menuppal
  *
- * - visible=1
  * - main=1
- * - ordenació natural
+ * - ordenació natural per order_code
+ * - sense ordre (order_code buit) al final
  * - màxim 5 botons per fila
  * - espai sobrant repartit
  */
@@ -16,7 +16,6 @@ $Pagines = TableRegistry::getTableLocator()->get('Pagines');
 $pages = $Pagines->find()
     ->select(['id', 'title', 'description', 'order_code', 'link'])
     ->where([
-        'visible' => 1,
         'main' => 1,
     ])
     ->all()
@@ -24,8 +23,24 @@ $pages = $Pagines->find()
 
 /* Ordenació natural */
 usort($pages, function ($a, $b) {
-    $pa = array_map('intval', explode('.', (string)$a->order_code));
-    $pb = array_map('intval', explode('.', (string)$b->order_code));
+    $orderA = trim((string)$a->order_code);
+    $orderB = trim((string)$b->order_code);
+
+    $emptyA = ($orderA === '');
+    $emptyB = ($orderB === '');
+
+    if ($emptyA && !$emptyB) {
+        return 1;
+    }
+    if (!$emptyA && $emptyB) {
+        return -1;
+    }
+    if ($emptyA && $emptyB) {
+        return 0;
+    }
+
+    $pa = array_map('intval', explode('.', $orderA));
+    $pb = array_map('intval', explode('.', $orderB));
 
     $len = max(count($pa), count($pb));
     for ($idx = 0; $idx < $len; $idx++) {

--- a/templates/layout/default.php
+++ b/templates/layout/default.php
@@ -14,8 +14,24 @@ $pages = $Pagines->find()
  * Ordenació "natural" per order_code: 1, 1.1, 1.2, 2, 10, 10.1...
  */
 usort($pages, function ($a, $b) {
-    $pa = array_map('intval', explode('.', (string)$a->order_code));
-    $pb = array_map('intval', explode('.', (string)$b->order_code));
+    $orderA = trim((string)$a->order_code);
+    $orderB = trim((string)$b->order_code);
+
+    $emptyA = ($orderA === '');
+    $emptyB = ($orderB === '');
+
+    if ($emptyA && !$emptyB) {
+        return 1;
+    }
+    if (!$emptyA && $emptyB) {
+        return -1;
+    }
+    if ($emptyA && $emptyB) {
+        return 0;
+    }
+
+    $pa = array_map('intval', explode('.', $orderA));
+    $pb = array_map('intval', explode('.', $orderB));
 
     $len = max(count($pa), count($pb));
     for ($i = 0; $i < $len; $i++) {

--- a/templates/layout/default.php
+++ b/templates/layout/default.php
@@ -116,6 +116,34 @@ $isMenuPpalLayout = str_contains($appMainClass, 'has-menuppal');
         </div>
     </div>
 
+    <!-- Branding TOPBAR (NOMÉS DESKTOP en pàgines amb menuppal) -->
+    <div class="topbar-brand topbar-brand--desktop-menuppal">
+        <?= $this->Html->image('logoGran.png', [
+            'alt' => 'CFA Guinardó',
+            'class' => 'app-topbar__logo'
+        ]) ?>
+
+        <div class="app-topbar__social">
+            <?= $this->Html->link(
+                $this->Html->image('instagram.png', [
+                    'alt' => 'Instagram',
+                    'class' => 'app-topbar__socialIcon'
+                ]),
+                'https://www.instagram.com/cfaguinardo',
+                ['escape' => false, 'target' => '_blank', 'rel' => 'noopener']
+            ) ?>
+
+            <?= $this->Html->link(
+                $this->Html->image('facebook.png', [
+                    'alt' => 'Facebook',
+                    'class' => 'app-topbar__socialIcon'
+                ]),
+                'https://www.facebook.com/people/Cfa-Guinardo/61560117734842/',
+                ['escape' => false, 'target' => '_blank', 'rel' => 'noopener']
+            ) ?>
+        </div>
+    </div>
+
     <!-- CTA (NOMÉS DESKTOP) -->
     <?= $this->Html->link(
         'INSCRIU-TE',

--- a/templates/layout/default.php
+++ b/templates/layout/default.php
@@ -52,6 +52,9 @@ $pageLevel = function (string $orderCode): int {
     $orderCode = trim($orderCode);
     return $orderCode === '' ? 1 : count(explode('.', $orderCode));
 };
+
+$appMainClass = trim((string)$this->fetch('appMainClass'));
+$isMenuPpalLayout = str_contains($appMainClass, 'has-menuppal');
 ?>
 <!DOCTYPE html>
 <html lang="ca">
@@ -70,7 +73,7 @@ $pageLevel = function (string $orderCode): int {
     <?= $this->fetch('calendar') ?>
     <?= $this->fetch('script') ?>
 </head>
-<body>
+<body class="<?= $isMenuPpalLayout ? 'is-menuppal-page' : 'is-regular-page' ?>">
 
 <!-- TOPBAR -->
 <header class="app-topbar" id="appTopbar">
@@ -188,7 +191,7 @@ $pageLevel = function (string $orderCode): int {
     </aside>
 
     <!-- CONTINGUT -->
-    <main class="app-main <?= h(trim((string)$this->fetch('appMainClass'))) ?>">
+    <main class="app-main <?= h($appMainClass) ?>">
         <div class="app-container">
             <?= $this->Flash->render() ?>
             <?= $this->fetch('content') ?>

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -143,11 +143,17 @@
     display: block;
     border-right: 3px solid var(--section-color);
     border-left: 3px solid var(--section-color);
-    border-bottom: 3px solid var(--section-color);
+    border-bottom: 0;
   }
 
-  .horaris-course-table tbody tr + tr{
+  .horaris-course-table tbody tr:has(> .horaris-course-table__course){
+    border-top: 3px solid var(--section-color);
     margin-top: .55rem;
+  }
+
+  .horaris-course-table tbody tr:last-child,
+  .horaris-course-table tbody tr:has(+ tr > .horaris-course-table__course){
+    border-bottom: 3px solid var(--section-color);
   }
 
   .horaris-course-table__course,
@@ -163,7 +169,7 @@
   }
 
   .horaris-course-table__course{
-    border-top: 3px solid var(--section-color) !important;
+    border-top: 0 !important;
     border-left: 0 !important;
   }
 

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -50,6 +50,7 @@
   background: var(--section-color);
   color: #fff;
   font-family: 'Bebas Neue', Bebas, Arial, sans-serif;
+  font-weight: 400;
   font-size: 1.5rem;
   line-height: 1.8rem;
   border: 0;
@@ -67,7 +68,7 @@
   font-weight: 400;
   letter-spacing: .01em;
   line-height: 1.1;
-  padding: .42rem .75rem .42rem .5rem;
+  padding: .42rem .75rem .42rem 1rem !important;
   text-align: left;
   vertical-align: middle;
   border: 0;

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -175,13 +175,16 @@
 
   .horaris-course-table__aula{
     text-align: left;
-    padding-top: .55rem;
-    margin-top: .2rem;
-    border-top: 1px solid rgba(0,0,0,.14) !important;
   }
 
   .horaris-course-table__days{
-    padding-bottom: .45rem;
+    padding-bottom: .2rem;
+  }
+
+  .horaris-course-table__row--parent .horaris-course-table__aula{
+    padding-bottom: .55rem;
+    margin-bottom: .2rem;
+    border-bottom: 1px solid rgba(0,0,0,.14) !important;
   }
 
   .horaris-course-table__aula-head{ font-size: 1.25rem; }

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -1,0 +1,93 @@
+.horaris-board{
+  font-family: 'Roboto Condensed', Arial, sans-serif;
+  color: #3f3f3f;
+  max-width: 980px;
+  margin: 0 auto;
+}
+
+.horaris-board__actions{
+  display: flex;
+  justify-content: center;
+  margin: 0 0 1.2rem;
+}
+
+.horaris-board__download-btn{
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  padding: 0.35rem 1rem;
+  background: #dd4f84;
+  color: #fff;
+  text-decoration: none;
+  font-family: 'Bebas Neue', Bebas, Arial, sans-serif;
+  font-size: 1.35rem;
+  letter-spacing: .02em;
+}
+
+.horaris-section{
+  position: relative;
+  margin: 0 auto 1rem;
+  border: 2px solid var(--section-color);
+  border-top: 0;
+}
+
+.horaris-section__header{
+  position: absolute;
+  right: -2px;
+  top: -1.85rem;
+  width: 120px;
+  height: 1.85rem;
+  background: var(--section-color);
+  color: #fff;
+  font-family: 'Bebas Neue', Bebas, Arial, sans-serif;
+  font-size: 1.5rem;
+  line-height: 1.85rem;
+  text-align: center;
+}
+
+.horaris-section__table{
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.horaris-section__table tr + tr{
+  border-top: 1px solid #d8d8d8;
+}
+
+.horaris-section__course{
+  width: 31%;
+  background: var(--section-color);
+  color: #fff;
+  font-family: 'Bebas Neue', Bebas, Arial, sans-serif;
+  font-size: 1.6rem;
+  font-weight: 400;
+  letter-spacing: .01em;
+  line-height: 1.1;
+  padding: .42rem .75rem;
+  text-align: center;
+  vertical-align: middle;
+}
+
+.horaris-section__days,
+.horaris-section__hours,
+.horaris-section__aula{
+  background: #fff;
+  padding: .35rem .6rem;
+  font-size: 1.32rem;
+  line-height: 1.2;
+  vertical-align: middle;
+}
+
+.horaris-section__days{ width: 35%; text-align: left; }
+.horaris-section__hours{ width: 22%; text-align: left; }
+.horaris-section__aula{ width: 12%; text-align: center; }
+
+@media (max-width: 900px){
+  .horaris-section__header{ width: 95px; font-size: 1.25rem; }
+  .horaris-section__course{ font-size: 1.2rem; }
+  .horaris-section__days,
+  .horaris-section__hours,
+  .horaris-section__aula{ font-size: 1rem; }
+}

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -130,6 +130,12 @@
   border-bottom: 3px solid var(--section-color);
 }
 
+@media (min-width: 901px){
+  .horaris-course-table__course[rowspan]{
+    border-bottom: 3px solid var(--section-color);
+  }
+}
+
 @media (max-width: 900px){
   .horaris-course-table{
     table-layout: auto;

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -68,7 +68,7 @@
   letter-spacing: .01em;
   line-height: 1.1;
   padding: .42rem .75rem;
-  text-align: center;
+  text-align: left;
   vertical-align: middle;
   border: 0;
   border-left: 3px solid var(--section-color);

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -131,6 +131,46 @@
 }
 
 @media (max-width: 900px){
+  .horaris-course-table{
+    table-layout: auto;
+  }
+
+  .horaris-course-table thead{
+    display: none;
+  }
+
+  .horaris-course-table tbody tr{
+    display: block;
+    border-right: 3px solid var(--section-color);
+    border-left: 3px solid var(--section-color);
+    border-bottom: 3px solid var(--section-color);
+  }
+
+  .horaris-course-table tbody tr + tr{
+    margin-top: .55rem;
+  }
+
+  .horaris-course-table__course,
+  .horaris-course-table__days,
+  .horaris-course-table__hours,
+  .horaris-course-table__aula{
+    display: block;
+    width: 100%;
+    text-align: left;
+    border: 0 !important;
+    padding-left: .9rem;
+    padding-right: .9rem;
+  }
+
+  .horaris-course-table__course{
+    border-top: 3px solid var(--section-color) !important;
+    border-left: 0 !important;
+  }
+
+  .horaris-course-table__aula{
+    text-align: left;
+  }
+
   .horaris-course-table__aula-head{ font-size: 1.25rem; }
   .horaris-course-table__course{ font-size: 1.2rem; }
   .horaris-course-table__days,

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -59,7 +59,7 @@
 }
 
 .horaris-course-table__course{
-  width: 28%;
+  width: 36%;
   background: var(--section-color);
   color: #fff;
   font-family: 'Bebas Neue', Bebas, Arial, sans-serif;
@@ -86,7 +86,7 @@
 }
 
 .horaris-course-table__days{ width: 35%; text-align: left; }
-.horaris-course-table__hours{ width: 19%; text-align: left; }
+.horaris-course-table__hours{ width: 11%; text-align: left; }
 .horaris-course-table__aula{
   width: 18%;
   text-align: center;

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -175,6 +175,11 @@
 
   .horaris-course-table__aula{
     text-align: left;
+    padding-top: .3rem;
+  }
+
+  .horaris-course-table__days{
+    padding-bottom: .2rem;
   }
 
   .horaris-course-table__aula-head{ font-size: 1.25rem; }

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -188,7 +188,7 @@
   }
 
   .horaris-course-table__row--parent:has(+ tr.horaris-course-table__row--parent) .horaris-course-table__aula{
-    margin-bottom: 2rem;
+    padding-bottom: 2rem;
   }
 
   .horaris-course-table__aula-head{ font-size: 1.25rem; }

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -175,11 +175,13 @@
 
   .horaris-course-table__aula{
     text-align: left;
-    padding-top: .3rem;
+    padding-top: .55rem;
+    margin-top: .2rem;
+    border-top: 1px solid rgba(0,0,0,.14) !important;
   }
 
   .horaris-course-table__days{
-    padding-bottom: .2rem;
+    padding-bottom: .45rem;
   }
 
   .horaris-course-table__aula-head{ font-size: 1.25rem; }

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -24,11 +24,14 @@
   font-size: 1.35rem;
   letter-spacing: .02em;
 }
+.horaris-board__download-btn:visited,
+.horaris-board__download-btn:hover,
+.horaris-board__download-btn:focus{
+  color: #fff;
+}
 
 .horaris-section{
   margin: 0 auto 1rem;
-  display: grid;
-  gap: .95rem;
 }
 
 .horaris-course-table{
@@ -85,9 +88,12 @@
 .horaris-course-table__hours{ width: 22%; text-align: left; }
 .horaris-course-table__aula{ width: 12%; text-align: center; }
 
-/* Vora superior de la primera fila d'horari com la vora exterior */
+/* Primera fila sense vora superior; cantonada superior esquerra també sense vora */
 .horaris-course-table tbody tr:first-child > *{
-  border-top: 2px solid var(--section-color);
+  border-top: 0;
+}
+.horaris-course-table tbody tr:first-child > :first-child{
+  border-left: 0;
 }
 
 @media (max-width: 900px){

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -71,6 +71,7 @@
   text-align: center;
   vertical-align: middle;
   border: 0;
+  border-left: 3px solid var(--section-color);
 }
 
 .horaris-course-table__days,
@@ -117,18 +118,10 @@
   border-right: 3px solid var(--section-color);
 }
 
-/* Vora esquerra pintada a totes les files menys la primera */
-.horaris-course-table tbody tr:not(:first-child) > *:first-child{
-  border-left: 3px solid var(--section-color);
-}
-
-/* Primera fila: sense vora esquerra ni superior, però amb vora inferior pintada */
+/* Primera fila del cos: sense vora superior i inferior */
 .horaris-course-table tbody tr:first-child > *{
   border-top: 0;
-  border-bottom: 3px solid var(--section-color);
-}
-.horaris-course-table tbody tr:first-child > :first-child{
-  border-left: 0;
+  border-bottom: 0;
 }
 
 /* Vora inferior de la taula (gruix 3) */

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -27,7 +27,7 @@
 .horaris-board__download-btn:visited,
 .horaris-board__download-btn:hover,
 .horaris-board__download-btn:focus{
-  color: #fff;
+  color: #fff !important;
 }
 
 .horaris-section{
@@ -38,7 +38,6 @@
   width: 100%;
   border-collapse: collapse;
   table-layout: fixed;
-  border: 2px solid var(--section-color);
 }
 
 .horaris-course-table__spacer{
@@ -56,6 +55,7 @@
   border: 0;
   text-align: center;
   width: 12%;
+  border-right: 3px solid var(--section-color);
 }
 
 .horaris-course-table__course{
@@ -88,12 +88,36 @@
 .horaris-course-table__hours{ width: 22%; text-align: left; }
 .horaris-course-table__aula{ width: 12%; text-align: center; }
 
-/* Primera fila sense vora superior; cantonada superior esquerra també sense vora */
+/* Vores interiors invisibles */
+.horaris-course-table tbody tr > *{
+  border-left: 0;
+  border-right: 0;
+  border-top: 0;
+  border-bottom: 0;
+}
+
+/* Vora dreta de tota la taula (gruix 3) */
+.horaris-course-table tbody tr > *:last-child{
+  border-right: 3px solid var(--section-color);
+}
+
+/* Vora esquerra pintada a totes les files menys la primera */
+.horaris-course-table tbody tr:not(:first-child) > *:first-child{
+  border-left: 3px solid var(--section-color);
+}
+
+/* Primera fila: sense vora esquerra ni superior, però amb vora inferior pintada */
 .horaris-course-table tbody tr:first-child > *{
   border-top: 0;
+  border-bottom: 3px solid var(--section-color);
 }
 .horaris-course-table tbody tr:first-child > :first-child{
   border-left: 0;
+}
+
+/* Vora inferior de la taula (gruix 3) */
+.horaris-course-table tbody tr:last-child > *{
+  border-bottom: 3px solid var(--section-color);
 }
 
 @media (max-width: 900px){

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -18,7 +18,7 @@
   min-height: 42px;
   padding: 0.35rem 1rem;
   background: #dd4f84;
-  color: #fff;
+  color: #fff !important;
   text-decoration: none;
   font-family: 'Bebas Neue', Bebas, Arial, sans-serif;
   font-size: 1.35rem;
@@ -54,12 +54,12 @@
   line-height: 1.8rem;
   border: 0;
   text-align: center;
-  width: 12%;
-  border-right: 3px solid var(--section-color);
+  width: 18%;
+  border: 3px solid var(--section-color);
 }
 
 .horaris-course-table__course{
-  width: 31%;
+  width: 28%;
   background: var(--section-color);
   color: #fff;
   font-family: 'Bebas Neue', Bebas, Arial, sans-serif;
@@ -85,8 +85,24 @@
 }
 
 .horaris-course-table__days{ width: 35%; text-align: left; }
-.horaris-course-table__hours{ width: 22%; text-align: left; }
-.horaris-course-table__aula{ width: 12%; text-align: center; }
+.horaris-course-table__hours{ width: 19%; text-align: left; }
+.horaris-course-table__aula{
+  width: 18%;
+  text-align: center;
+  white-space: nowrap;
+}
+
+/* Primera fila real de la taula (capçalera): interiors a 0 i inferior pintada */
+.horaris-course-table thead tr > *{
+  border-top: 0;
+  border-left: 0;
+  border-right: 0;
+  border-bottom: 3px solid var(--section-color);
+}
+
+.horaris-course-table thead tr > *:last-child{
+  border: 3px solid var(--section-color);
+}
 
 /* Vores interiors invisibles */
 .horaris-course-table tbody tr > *{

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -119,10 +119,10 @@
   border-right: 3px solid var(--section-color);
 }
 
-/* Primera fila del cos: sense vora superior i inferior */
+/* Primera fila del cos: sense vora superior */
 .horaris-course-table tbody tr:first-child > *{
   border-top: 0;
-  border-bottom: 0;
+  /* border-bottom: 0; */
 }
 
 /* Vora inferior de la taula (gruix 3) */

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -67,7 +67,7 @@
   font-weight: 400;
   letter-spacing: .01em;
   line-height: 1.1;
-  padding: .42rem .75rem;
+  padding: .42rem .75rem .42rem .95rem;
   text-align: left;
   vertical-align: middle;
   border: 0;

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -182,9 +182,13 @@
   }
 
   .horaris-course-table__row--parent .horaris-course-table__aula{
-    padding-bottom: .55rem;
-    margin-bottom: .2rem;
-    border-bottom: 1px solid rgba(0,0,0,.14) !important;
+    padding-bottom: 0;
+    margin-bottom: 0;
+    border-bottom: 0 !important;
+  }
+
+  .horaris-course-table__row--parent:has(+ tr.horaris-course-table__row--parent) .horaris-course-table__aula{
+    margin-bottom: 2rem;
   }
 
   .horaris-course-table__aula-head{ font-size: 1.25rem; }

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -67,7 +67,7 @@
   font-weight: 400;
   letter-spacing: .01em;
   line-height: 1.1;
-  padding: .42rem .75rem .42rem .95rem;
+  padding: .42rem .75rem .42rem .5rem;
   text-align: left;
   vertical-align: middle;
   border: 0;

--- a/webroot/css/horaris.css
+++ b/webroot/css/horaris.css
@@ -26,37 +26,36 @@
 }
 
 .horaris-section{
-  position: relative;
   margin: 0 auto 1rem;
-  border: 2px solid var(--section-color);
-  border-top: 0;
+  display: grid;
+  gap: .95rem;
 }
 
-.horaris-section__header{
-  position: absolute;
-  right: -2px;
-  top: -1.85rem;
-  width: 120px;
-  height: 1.85rem;
+.horaris-course-table{
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+  border: 2px solid var(--section-color);
+}
+
+.horaris-course-table__spacer{
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.horaris-course-table__aula-head{
   background: var(--section-color);
   color: #fff;
   font-family: 'Bebas Neue', Bebas, Arial, sans-serif;
   font-size: 1.5rem;
-  line-height: 1.85rem;
+  line-height: 1.8rem;
+  border: 0;
   text-align: center;
+  width: 12%;
 }
 
-.horaris-section__table{
-  width: 100%;
-  border-collapse: collapse;
-  table-layout: fixed;
-}
-
-.horaris-section__table tr + tr{
-  border-top: 1px solid #d8d8d8;
-}
-
-.horaris-section__course{
+.horaris-course-table__course{
   width: 31%;
   background: var(--section-color);
   color: #fff;
@@ -68,26 +67,33 @@
   padding: .42rem .75rem;
   text-align: center;
   vertical-align: middle;
+  border: 0;
 }
 
-.horaris-section__days,
-.horaris-section__hours,
-.horaris-section__aula{
+.horaris-course-table__days,
+.horaris-course-table__hours,
+.horaris-course-table__aula{
   background: #fff;
   padding: .35rem .6rem;
   font-size: 1.32rem;
   line-height: 1.2;
   vertical-align: middle;
+  border: 0;
 }
 
-.horaris-section__days{ width: 35%; text-align: left; }
-.horaris-section__hours{ width: 22%; text-align: left; }
-.horaris-section__aula{ width: 12%; text-align: center; }
+.horaris-course-table__days{ width: 35%; text-align: left; }
+.horaris-course-table__hours{ width: 22%; text-align: left; }
+.horaris-course-table__aula{ width: 12%; text-align: center; }
+
+/* Vora superior de la primera fila d'horari com la vora exterior */
+.horaris-course-table tbody tr:first-child > *{
+  border-top: 2px solid var(--section-color);
+}
 
 @media (max-width: 900px){
-  .horaris-section__header{ width: 95px; font-size: 1.25rem; }
-  .horaris-section__course{ font-size: 1.2rem; }
-  .horaris-section__days,
-  .horaris-section__hours,
-  .horaris-section__aula{ font-size: 1rem; }
+  .horaris-course-table__aula-head{ font-size: 1.25rem; }
+  .horaris-course-table__course{ font-size: 1.2rem; }
+  .horaris-course-table__days,
+  .horaris-course-table__hours,
+  .horaris-course-table__aula{ font-size: 1rem; }
 }

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -370,12 +370,27 @@ body{ margin: 0; }
   /* Si hi ha menuppal, el menú lateral queda a dalt
      amb un marge superior de l'alçada del logotip */
   body.is-menuppal-page .app-sidebar{
-    display: block;
+    display: none !important;
   }
 
   body.is-menuppal-page .app-sidebar__content{
     width: 100%;
     margin-top: calc(6rem + 0.35rem + 2.2rem + 0.6rem);
+  }
+
+  body.is-menuppal-page .app-topbar{
+    left: 0;
+    width: 100%;
+  }
+
+  body.is-menuppal-page .app-main{
+    left: 0;
+    width: 100%;
+  }
+
+  body.is-menuppal-page .app-bottombar{
+    left: 0;
+    width: 100%;
   }
 
   /* Contenidor shell neutre */

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -364,7 +364,7 @@ body{ margin: 0; }
 
   body.is-menuppal-page .app-sidebar__content{
     width: 100%;
-    margin-top: calc(6rem + 0.35rem + 2.2rem);
+    margin-top: calc(6rem + 0.35rem + 2.2rem + 0.6rem);
   }
 
   /* Contenidor shell neutre */

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -370,27 +370,12 @@ body{ margin: 0; }
   /* Si hi ha menuppal, el menú lateral queda a dalt
      amb un marge superior de l'alçada del logotip */
   body.is-menuppal-page .app-sidebar{
-    display: none !important;
+    display: block;
   }
 
   body.is-menuppal-page .app-sidebar__content{
     width: 100%;
     margin-top: calc(6rem + 0.35rem + 2.2rem + 0.6rem);
-  }
-
-  body.is-menuppal-page .app-topbar{
-    left: 0;
-    width: 100%;
-  }
-
-  body.is-menuppal-page .app-main{
-    left: 0;
-    width: 100%;
-  }
-
-  body.is-menuppal-page .app-bottombar{
-    left: 0;
-    width: 100%;
   }
 
   /* Contenidor shell neutre */

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -337,18 +337,28 @@ body{ margin: 0; }
   */
   .sidebar-brand--desktop{
     position: fixed;
-    top: 10px;
+    top: 14px;
     left: calc((100vw + var(--sidebar-w)) / 2);
     transform: translateX(-50%);
-    width: min(260px, calc(100vw - var(--sidebar-w) - 2rem));
+    width: min(320px, calc(100vw - var(--sidebar-w) - 2rem));
     margin: 0;
     transition: left 420ms cubic-bezier(.2,.8,.2,1);
     z-index: 1100;
   }
 
+  body.is-menuppal-page .sidebar-brand--desktop{
+    left: calc((100vw + var(--sidebar-w)) / 2);
+  }
+
   body.is-regular-page .sidebar-brand--desktop{
     left: calc(var(--sidebar-w) / 2);
     width: min(240px, calc(var(--sidebar-w) - 24px));
+  }
+
+  /* En pàgines normals, deixem espai perquè el branding no se superposi
+     als botons del menú lateral. */
+  body.is-regular-page .app-sidebar__content{
+    padding-top: 7.5rem;
   }
 
   @media (prefers-reduced-motion: reduce){

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -344,6 +344,17 @@ body{ margin: 0; }
 
     border: 0;
     margin: 0;
+    display: block;
+    visibility: visible;
+    opacity: 1;
+    transform: none;
+  }
+
+  .app-sidebar[aria-hidden="true"]{
+    display: block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+    transform: none !important;
   }
 
   /* En desktop, SÍ es veu el branding dins sidebar (pàgines normals) */

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -4,7 +4,7 @@
 
   /* DESKTOP (10/80/10) */
   --topbar-h-desktop: 10vh;
-  --bottombar-h-desktop: 26vh;
+  --bottombar-h-desktop: calc(26vh + 0.5rem);
 
   --sidebar-w: 280px;
   --pink: #e83e8c;
@@ -111,6 +111,53 @@ body{ margin: 0; }
   margin-bottom: 0.5rem;
 }
 
+.app-sidebar__content .sidebar-item{
+  opacity: 0;
+  transform: translateX(-28px);
+  animation: sidebarItemSlideInLeft 520ms cubic-bezier(.2,.8,.2,1) forwards;
+}
+
+@keyframes sidebarItemSlideInLeft{
+  0%{
+    opacity: 0;
+    transform: translateX(-28px);
+  }
+  100%{
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+/* Escalonat (botó per botó) */
+.app-sidebar__content .sidebar-item:nth-child(1){ animation-delay: 0ms; }
+.app-sidebar__content .sidebar-item:nth-child(2){ animation-delay: 90ms; }
+.app-sidebar__content .sidebar-item:nth-child(3){ animation-delay: 180ms; }
+.app-sidebar__content .sidebar-item:nth-child(4){ animation-delay: 270ms; }
+.app-sidebar__content .sidebar-item:nth-child(5){ animation-delay: 360ms; }
+.app-sidebar__content .sidebar-item:nth-child(6){ animation-delay: 450ms; }
+.app-sidebar__content .sidebar-item:nth-child(7){ animation-delay: 540ms; }
+.app-sidebar__content .sidebar-item:nth-child(8){ animation-delay: 630ms; }
+.app-sidebar__content .sidebar-item:nth-child(9){ animation-delay: 720ms; }
+.app-sidebar__content .sidebar-item:nth-child(10){ animation-delay: 810ms; }
+.app-sidebar__content .sidebar-item:nth-child(11){ animation-delay: 900ms; }
+.app-sidebar__content .sidebar-item:nth-child(12){ animation-delay: 990ms; }
+.app-sidebar__content .sidebar-item:nth-child(13){ animation-delay: 1080ms; }
+.app-sidebar__content .sidebar-item:nth-child(14){ animation-delay: 1170ms; }
+.app-sidebar__content .sidebar-item:nth-child(15){ animation-delay: 1260ms; }
+.app-sidebar__content .sidebar-item:nth-child(16){ animation-delay: 1350ms; }
+.app-sidebar__content .sidebar-item:nth-child(17){ animation-delay: 1440ms; }
+.app-sidebar__content .sidebar-item:nth-child(18){ animation-delay: 1530ms; }
+.app-sidebar__content .sidebar-item:nth-child(19){ animation-delay: 1620ms; }
+.app-sidebar__content .sidebar-item:nth-child(20){ animation-delay: 1710ms; }
+
+@media (prefers-reduced-motion: reduce){
+  .app-sidebar__content .sidebar-item{
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
+}
+
 .app-sidebar .sidebar-item .bototext{
   transition: transform 160ms ease, box-shadow 180ms ease, background-color 0.3s;
   transform-origin: center;
@@ -170,7 +217,7 @@ body{ margin: 0; }
 }
 
 .app-bottombar__inner{
-  padding: 12px;
+  padding: 12.5px;
 }
 
 /* Textos bottombar */
@@ -520,7 +567,7 @@ body{ margin: 0; }
   /* En mòbil, 3 blocs en vertical */
   .app-bottombar__inner{
     display: block;
-    padding: 12px;
+    padding: 12.5px;
   }
 
   .app-bottombar__inner > section:nth-child(1){

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -330,6 +330,33 @@ body{ margin: 0; }
     display: block;
   }
 
+  /* Logo + socials:
+     - a pàgines amb menuppal: centrat amb l'àrea principal
+     - a la resta: cap a l'esquerra, centrat amb el menú lateral
+     El moviment és animat.
+  */
+  .sidebar-brand--desktop{
+    position: fixed;
+    top: 10px;
+    left: calc((100vw + var(--sidebar-w)) / 2);
+    transform: translateX(-50%);
+    width: min(260px, calc(100vw - var(--sidebar-w) - 2rem));
+    margin: 0;
+    transition: left 420ms cubic-bezier(.2,.8,.2,1);
+    z-index: 1100;
+  }
+
+  body.is-regular-page .sidebar-brand--desktop{
+    left: calc(var(--sidebar-w) / 2);
+    width: min(240px, calc(var(--sidebar-w) - 24px));
+  }
+
+  @media (prefers-reduced-motion: reduce){
+    .sidebar-brand--desktop{
+      transition: none;
+    }
+  }
+
   /* Contenidor shell neutre */
   .app-shell{
     padding: 0;

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -307,6 +307,24 @@ body{ margin: 0; }
     display: none;
   }
 
+  /* Branding a topbar només quan la pàgina conté menuppal */
+  .topbar-brand--desktop-menuppal{
+    display: none;
+  }
+
+  body.is-menuppal-page .topbar-brand--desktop-menuppal{
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    text-align: center;
+    pointer-events: auto;
+  }
+
   /* Sidebar fixa 100vh */
   .app-sidebar{
     position: fixed;
@@ -325,46 +343,14 @@ body{ margin: 0; }
     margin: 0;
   }
 
-  /* En desktop, SÍ es veu el branding dins sidebar */
+  /* En desktop, SÍ es veu el branding dins sidebar (pàgines normals) */
   .sidebar-brand{
     display: block;
   }
 
-  /* Logo + socials:
-     - a pàgines amb menuppal: centrat amb l'àrea principal
-     - a la resta: cap a l'esquerra, centrat amb el menú lateral
-     El moviment és animat.
-  */
-  .sidebar-brand--desktop{
-    position: fixed;
-    top: 14px;
-    left: calc((100vw + var(--sidebar-w)) / 2);
-    transform: translateX(-50%);
-    width: min(320px, calc(100vw - var(--sidebar-w) - 2rem));
-    margin: 0;
-    transition: left 420ms cubic-bezier(.2,.8,.2,1);
-    z-index: 1100;
-  }
-
+  /* Si hi ha menuppal, el branding es veu a topbar i no al lateral */
   body.is-menuppal-page .sidebar-brand--desktop{
-    left: calc((100vw + var(--sidebar-w)) / 2);
-  }
-
-  body.is-regular-page .sidebar-brand--desktop{
-    left: calc(var(--sidebar-w) / 2);
-    width: min(240px, calc(var(--sidebar-w) - 24px));
-  }
-
-  /* En pàgines normals, deixem espai perquè el branding no se superposi
-     als botons del menú lateral. */
-  body.is-regular-page .app-sidebar__content{
-    padding-top: 7.5rem;
-  }
-
-  @media (prefers-reduced-motion: reduce){
-    .sidebar-brand--desktop{
-      transition: none;
-    }
+    display: none;
   }
 
   /* Contenidor shell neutre */
@@ -507,6 +493,10 @@ body{ margin: 0; }
     align-items: center;
     justify-content: center;
     text-align: center;
+  }
+
+  .topbar-brand--desktop-menuppal{
+    display: none !important;
   }
 
   /* Centra també la fila d’icones + botó MENU */

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -314,9 +314,12 @@ body{ margin: 0; }
 
   body.is-menuppal-page .topbar-brand--desktop-menuppal{
     position: absolute;
-    left: 0;
-    right: 0;
-    top: 8px;
+    left: 50%;
+    right: auto;
+    top: 6px;
+    transform: translateX(-50%);
+    width: max-content;
+    max-width: calc(100% - 220px);
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -364,7 +364,7 @@ body{ margin: 0; }
 
   body.is-menuppal-page .app-sidebar__content{
     width: 100%;
-    margin-top: 6rem;
+    margin-top: calc(6rem + 0.35rem + 2.2rem);
   }
 
   /* Contenidor shell neutre */

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -356,6 +356,17 @@ body{ margin: 0; }
     display: none;
   }
 
+  /* Si hi ha menuppal, el menú lateral queda centrat verticalment */
+  body.is-menuppal-page .app-sidebar{
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  body.is-menuppal-page .app-sidebar__content{
+    width: 100%;
+  }
+
   /* Contenidor shell neutre */
   .app-shell{
     padding: 0;

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -356,15 +356,15 @@ body{ margin: 0; }
     display: none;
   }
 
-  /* Si hi ha menuppal, el menú lateral queda centrat verticalment */
+  /* Si hi ha menuppal, el menú lateral queda a dalt
+     amb un marge superior de l'alçada del logotip */
   body.is-menuppal-page .app-sidebar{
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
+    display: block;
   }
 
   body.is-menuppal-page .app-sidebar__content{
     width: 100%;
+    margin-top: 6rem;
   }
 
   /* Contenidor shell neutre */


### PR DESCRIPTION
### Motivation

- Menu should include pages with hierarchical `order_code` values (containing dots) and order them in a natural, numeric way across components.

### Description

- Removed the `andWhere(['order_code NOT LIKE' => '%.%'])` filter so entries with dotted `order_code` are included in the menu data set.
- Replaced the previous digit-extraction comparator with a component-wise numeric comparer that splits `order_code` on `.` and compares each numeric part in sequence.
- Kept the existing rendering and color-cycling logic unchanged and added a trailing newline to the file.

### Testing

- Ran PHP linting with `php -l` on the modified file and it reported no syntax errors.
- Ran the project's automated test suite (`vendor/bin/phpunit`) and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e721b8f888832ab743fe02b365e2b3)