### PR TITLE
Add friendly public slugs for Pagines URLs

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -64,6 +64,8 @@ return function (RouteBuilder $routes): void {
         $builder->connect('/calendar', ['controller' => 'Calendar', 'action' => 'index']);
         $builder->connect('/calendar/pdf-annual', ['controller' => 'Calendar', 'action' => 'pdfAnnual']);
         $builder->connect('/calendar/pdf-monthly', ['controller' => 'Calendar', 'action' => 'pdfMonthly']);
+        $builder->connect('/pagines', ['controller' => 'Pagines', 'action' => 'index']);
+        $builder->connect('/horaris', ['controller' => 'Horaris', 'action' => 'index']);
 
         // URL antiga
         $builder->connect('/pagines/view/{identifier}', ['controller' => 'Pagines', 'action' => 'view'])
@@ -73,7 +75,7 @@ return function (RouteBuilder $routes): void {
         $builder->connect('/{slug}', ['controller' => 'Pagines', 'action' => 'view'], ['_name' => 'pagina:view'])
             ->setPass(['slug'])
             ->setPatterns([
-                'slug' => '(?!pagines$|pages$|calendar$|horaris$)[a-z0-9][a-z0-9-]*',
+                'slug' => '[a-z0-9-]+',
             ]);
         /*
          * Connect catchall routes for all controllers.

--- a/config/routes.php
+++ b/config/routes.php
@@ -65,7 +65,6 @@ return function (RouteBuilder $routes): void {
         $builder->connect('/calendar/pdf-annual', ['controller' => 'Calendar', 'action' => 'pdfAnnual']);
         $builder->connect('/calendar/pdf-monthly', ['controller' => 'Calendar', 'action' => 'pdfMonthly']);
         $builder->connect('/pagines', ['controller' => 'Pagines', 'action' => 'index']);
-        $builder->connect('/horaris', ['controller' => 'Horaris', 'action' => 'index']);
 
         // URL antiga
         $builder->connect('/pagines/view/{identifier}', ['controller' => 'Pagines', 'action' => 'view'])

--- a/config/routes.php
+++ b/config/routes.php
@@ -64,6 +64,17 @@ return function (RouteBuilder $routes): void {
         $builder->connect('/calendar', ['controller' => 'Calendar', 'action' => 'index']);
         $builder->connect('/calendar/pdf-annual', ['controller' => 'Calendar', 'action' => 'pdfAnnual']);
         $builder->connect('/calendar/pdf-monthly', ['controller' => 'Calendar', 'action' => 'pdfMonthly']);
+
+        // URL antiga
+        $builder->connect('/pagines/view/{identifier}', ['controller' => 'Pagines', 'action' => 'view'])
+            ->setPass(['identifier']);
+
+        // URL pública amigable basada en el títol/link de la pàgina
+        $builder->connect('/{slug}', ['controller' => 'Pagines', 'action' => 'view'], ['_name' => 'pagina:view'])
+            ->setPass(['slug'])
+            ->setPatterns([
+                'slug' => '(?!pagines$|pages$|calendar$|horaris$)[a-z0-9][a-z0-9-]*',
+            ]);
         /*
          * Connect catchall routes for all controllers.
          *

--- a/src/Controller/PaginesController.php
+++ b/src/Controller/PaginesController.php
@@ -68,9 +68,12 @@ class PaginesController extends AppController
             ->first();
 
         if (!$pagina) {
-            $pagina = $this->Pagines->find()->all()->match(function ($candidate) use ($lookup) {
-                return $candidate->slug === $lookup;
-            })->first();
+            $lookupSlug = mb_strtolower($lookupDecoded);
+            $pagina = $this->Pagines->find()->all()
+                ->filter(function ($candidate) use ($lookupSlug) {
+                    return $candidate->slug === $lookupSlug;
+                })
+                ->first();
         }
 
         if (!$pagina) {

--- a/src/Controller/PaginesController.php
+++ b/src/Controller/PaginesController.php
@@ -39,30 +39,38 @@ class PaginesController extends AppController
 
     /**
      * Pàgina pública
-     * /pagines/view/{id}
-     * /pagines/view/{title}
+     * /pagines/view/{identifier} (format antic)
+     * /{slug} (format nou)
      */
-    public function view(string $id)
+    public function view(string $identifier)
     {
-        $lookup = trim($id);
+        $lookup = trim($identifier);
         $pagina = null;
 
         if (ctype_digit($lookup)) {
             $pagina = $this->Pagines->find()
                 ->where(['Pagines.id' => (int)$lookup])
                 ->first();
+
+            if ($pagina) {
+                return $this->redirect(['_name' => 'pagina:view', 'slug' => $pagina->slug], 301);
+            }
         }
 
+        $lookupDecoded = urldecode($lookup);
+        $pagina = $this->Pagines->find()
+            ->where([
+                'OR' => [
+                    'Pagines.title' => $lookupDecoded,
+                    'Pagines.link' => $lookupDecoded,
+                ],
+            ])
+            ->first();
+
         if (!$pagina) {
-            $lookupDecoded = urldecode($lookup);
-            $pagina = $this->Pagines->find()
-                ->where([
-                    'OR' => [
-                        'Pagines.title' => $lookupDecoded,
-                        'Pagines.link' => $lookupDecoded,
-                    ],
-                ])
-                ->first();
+            $pagina = $this->Pagines->find()->all()->match(function ($candidate) use ($lookup) {
+                return $candidate->slug === $lookup;
+            })->first();
         }
 
         if (!$pagina) {

--- a/src/Model/Entity/Pagine.php
+++ b/src/Model/Entity/Pagine.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\Model\Entity;
 
 use Cake\ORM\Entity;
+use Cake\Utility\Text;
 
 /**
  * Pagine Entity
@@ -20,6 +21,8 @@ use Cake\ORM\Entity;
  */
 class Pagine extends Entity
 {
+    protected $_virtual = ['slug'];
+
     /**
      * Fields that can be mass assigned using newEntity() or patchEntity().
      *
@@ -29,6 +32,18 @@ class Pagine extends Entity
      *
      * @var array<string, bool>
      */
+    protected function _getSlug(): string
+    {
+        $raw = trim((string)($this->link ?: $this->title));
+        $slug = mb_strtolower((string)Text::slug($raw, '-'));
+
+        if ($slug === '') {
+            return (string)$this->id;
+        }
+
+        return trim($slug, '-');
+    }
+
     protected $_accessible = [
         'title' => true,
         'body' => true,

--- a/templates/element/cursos.php
+++ b/templates/element/cursos.php
@@ -243,10 +243,10 @@ if (!$latestYear) {
 }
 
 $paginaMatricula = $paginesTable->find()
-    ->select(['id'])
+    ->select(['id', 'title', 'link'])
     ->where(['Pagines.title' => 'Preinscripció i matrícula'])
     ->first();
-$matriculaUrl = $paginaMatricula ? $this->Url->build(['controller' => 'Pagines', 'action' => 'view', $paginaMatricula->id]) : '#';
+$matriculaUrl = $paginaMatricula ? $this->Url->build(['_name' => 'pagina:view', 'slug' => $paginaMatricula->slug]) : '#';
 
 $courses = $coursesTable->find()
     ->where([

--- a/templates/element/matriculacio.php
+++ b/templates/element/matriculacio.php
@@ -56,7 +56,7 @@ $toDateAtTime = static function ($date, string $time, DateTimeZone $timezone): ?
 
 $getPageUrlByTitle = static function (string $title) use ($Pagines) {
     $page = $Pagines->find()
-        ->select(['id', 'link'])
+        ->select(['id', 'title', 'link'])
         ->where(['title' => $title])
         ->first();
 
@@ -68,7 +68,7 @@ $getPageUrlByTitle = static function (string $title) use ($Pagines) {
         return $page->link;
     }
 
-    return ['controller' => 'Pagines', 'action' => 'view', $page->id];
+    return ['_name' => 'pagina:view', 'slug' => $page->slug];
 };
 
 $startPreinscripcio40 = $toDateAtTime($maxDates['datafipreinscripcio'], '00:00:00', $tz)?->modify('-40 days');

--- a/templates/element/menuppal.php
+++ b/templates/element/menuppal.php
@@ -66,7 +66,7 @@ $i = 0;
 
         $link = !empty($p->link)
             ? $p->link
-            : ['controller' => 'Pagines', 'action' => 'view', $p->id];
+            : ['_name' => 'pagina:view', 'slug' => $p->slug];
 
         $desc = trim((string)($p->description ?? ''));
     ?>

--- a/templates/layout/default.php
+++ b/templates/layout/default.php
@@ -208,7 +208,7 @@ $isMenuPpalLayout = str_contains($appMainClass, 'has-menuppal');
                     <?= $this->element('bototext', [
                         'text'  => $p->title,
                         'image' => null,
-                        'link'  => ['controller' => 'Pagines', 'action' => 'view', $p->id],
+                        'link'  => ['_name' => 'pagina:view', 'slug' => $p->slug],
                         'title' => $p->title,
                         'color' => $color,
                         'class' => 'btn-page'


### PR DESCRIPTION
### Motivation
- Provide SEO‑friendly public URLs so pages like `/pagines/view/10` are exposed as `/preinscripcio-i-matricula` (slugified `link`/`title`) while keeping legacy access working.

### Description
- Add a named public route `/{slug}` and a legacy route `/pagines/view/{identifier}` and a pattern to avoid colliding with internal routes in `config/routes.php`.
- Implement a virtual `slug` property in the `Pagine` entity that generates a lowercase, dash‑separated slug from `link` or `title` using `Text::slug` in `src/Model/Entity/Pagine.php`.
- Update `PaginesController::view()` to accept an `identifier`, load numeric IDs and issue a `301` redirect to the canonical slug URL, and resolve pages by `title`, `link` or `slug` in `src/Controller/PaginesController.php`.
- Replace ID-based URL generation in public templates/components to use the new named route (`pagina:view`) and slug, and ensure required fields are selected where needed in `templates/element/menuppal.php`, `templates/layout/default.php`, `templates/element/matriculacio.php`, and `templates/element/cursos.php`.

### Testing
- Ran syntax checks with `php -l` on `config/routes.php`, `src/Controller/PaginesController.php`, `src/Model/Entity/Pagine.php`, `templates/element/menuppal.php`, `templates/layout/default.php`, `templates/element/matriculacio.php`, and `templates/element/cursos.php`, all reporting no syntax errors. 
- Attempted `bin/cake routes` in this environment but it fails due to a runtime Chronos/PHP compatibility issue not related to these changes (reported as a local environment warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ea9ee5bc832aaeebcbe61912283a)