### PR TITLE
Set fixed browser title to CFA Guinardó

### DIFF
--- a/templates/layout/default.php
+++ b/templates/layout/default.php
@@ -61,7 +61,7 @@ $isMenuPpalLayout = str_contains($appMainClass, 'has-menuppal');
 <head>
     <?= $this->Html->charset() ?>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title><?= h($cakeDescription) ?>: <?= $this->fetch('title') ?></title>
+    <title>CFA Guinardó</title>
     <?= $this->Html->meta('icon') ?>
 
     <?= $this->Html->css(['fonts', 'cake']) ?>


### PR DESCRIPTION
### Motivation
- Ensure the browser tab title is consistent across all pages rendered with the default layout by using a fixed site title.

### Description
- Replaced the dynamic title in `templates/layout/default.php` with a fixed `<title>CFA Guinardó</title>` so every page using this layout shows the same browser title.

### Testing
- Ran `php -l templates/layout/default.php` to validate PHP syntax and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35a1e4e40832a9da5d494aff0d7b0)