### PR TITLE
Use `datainicipreinscripcio` for 40-day Preinscripció window

### DIFF
--- a/templates/element/matriculacio.php
+++ b/templates/element/matriculacio.php
@@ -16,6 +16,7 @@ $Pagines = TableRegistry::getTableLocator()->get('Pagines');
 
 $yearRows = $Years->find()
     ->select([
+        'datainicipreinscripcio',
         'datafipreinscripcio',
         'databaremprovisional',
         'datafireclamacions',
@@ -26,6 +27,7 @@ $yearRows = $Years->find()
     ->all();
 
 $maxDates = [
+    'datainicipreinscripcio' => null,
     'datafipreinscripcio' => null,
     'databaremprovisional' => null,
     'datafireclamacions' => null,
@@ -71,7 +73,7 @@ $getPageUrlByTitle = static function (string $title) use ($Pagines) {
     return ['_name' => 'pagina:view', 'slug' => $page->slug];
 };
 
-$startPreinscripcio40 = $toDateAtTime($maxDates['datafipreinscripcio'], '00:00:00', $tz)?->modify('-40 days');
+$startPreinscripcio40 = $toDateAtTime($maxDates['datainicipreinscripcio'], '00:00:00', $tz)?->modify('-40 days');
 $endPreinscripcio40 = $toDateAtTime($maxDates['datafipreinscripcio'], '23:59:59', $tz);
 
 $startBaremProvisional = $toDateAtTime($maxDates['databaremprovisional'], '20:00:00', $tz);
@@ -91,7 +93,7 @@ $targetTitle = 'Matrícula viva';
 
 /**
  * Condicions de redirecció:
- * 1) Si avui és dins els 40 dies anteriors a `datafipreinscripcio` (inclòs),
+ * 1) Si avui és dins els 40 dies anteriors a `datainicipreinscripcio` (inclòs),
  *    redirigim a "Preinscripció de juny".
  * 2) Si avui és entre les 20:00 CET de `databaremprovisional` i el final del
  *    dia de `datafireclamacions` (ambdós inclosos), redirigim a


### PR DESCRIPTION
### Motivation
- The 40-day trigger for the "Preinscripció de juny" redirect should be calculated from the preinscripció start date rather than the end date so the page becomes active at the intended time.

### Description
- Updated `templates/element/matriculacio.php` to include `datainicipreinscripcio` in the selected fields and in the `$maxDates` map and changed the 40-day window start to use `datainicipreinscripcio` (`->modify('-40 days')`) while keeping the window end anchored to `datafipreinscripcio` and adjusted the inline comment accordingly.

### Testing
- Ran `php -l templates/element/matriculacio.php` and the syntax check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06c4434100832abe4ab6c7aef05f18)