### PR TITLE
Add mobile INSCRIU-TE button to topbar for menuppal pages and reduce menu gap

### DIFF
--- a/templates/element/menuppal.php
+++ b/templates/element/menuppal.php
@@ -91,7 +91,7 @@ $i = 0;
 .menuppal-wrapper{
   display: flex;
   flex-wrap: wrap;
-  gap: 3rem;
+  gap: 1rem;
   justify-content: center;
 }
 

--- a/templates/layout/default.php
+++ b/templates/layout/default.php
@@ -113,6 +113,16 @@ $isMenuPpalLayout = str_contains($appMainClass, 'has-menuppal');
                 ['escape' => false, 'target' => '_blank', 'rel' => 'noopener']
             ) ?>
 
+            <?= $this->Html->link(
+                'INSCRIU-TE',
+                'http://www.cfaguinardo.cat/gestioalumnes/students/alta-inici',
+                [
+                    'class' => 'app-topbar__cta app-topbar__cta--mobile-social',
+                    'target' => '_blank',
+                    'rel' => 'noopener'
+                ]
+            ) ?>
+
         </div>
     </div>
 

--- a/webroot/css/layout_custom.css
+++ b/webroot/css/layout_custom.css
@@ -102,6 +102,10 @@ body{ margin: 0; }
   white-space: nowrap;
 }
 
+.app-topbar__cta--mobile-social{
+  display: none;
+}
+
 /* =========================
    SIDEBAR (base)
 ========================= */
@@ -513,11 +517,23 @@ body{ margin: 0; }
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    height: 2rem;
   }
 
-  /* En mòbil: NO mostrar Inscriu-te */
+  /* En mòbil: amaga el CTA desktop i mostra el CTA del grup social només al menú principal */
   .app-topbar__cta{
     display: none;
+  }
+
+  body.is-menuppal-page .app-topbar__cta--mobile-social{
+    display: inline-flex;
+    margin-left: 0;
+    height: 2rem;
+    max-height: 2rem;
+    padding: 0 0.6rem;
+    background: var(--pink);
+    font-size: 1.1rem;
+    line-height: 1;
   }
 
   /* Branding centrat dins topbar */


### PR DESCRIPTION
### Motivation
- Ensure the `INSCRIU-TE` CTA is visible on small screens when the page uses the main menu (`menuppal`) and keep it visually aligned with existing social buttons. 

### Description
- Inserted a mobile-only `INSCRIU-TE` link next to the Facebook icon inside the topbar social group and gave it the class `app-topbar__cta--mobile-social` in `templates/layout/default.php`. 
- Added CSS rules in `webroot/css/layout_custom.css` to hide the new CTA by default and show it on mobile for main-menu pages (`body.is-menuppal-page`), constrained its height to match the mobile `MENU` button and styled it with the pink variable `--pink`. 
- Reduced the `.menuppal-wrapper` spacing from `3rem` to `1rem` in `templates/element/menuppal.php` to tighten the layout on small screens. 

### Testing
- Ran `git diff --check` which reported no issues. 
- Ran PHP syntax checks with `php -l templates/layout/default.php` and `php -l templates/element/menuppal.php`, both succeeded. 
- Attempted `vendor/bin/phpunit --version` but it failed in this environment due to a Cake Chronos / PHP 8.5-dev signature incompatibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27fb7e157c832aa12a95695a347cd2)