### PR TITLE
Introduce responsive CSS variables and improve top-bar/sidebar responsiveness in cake.css

### DIFF
--- a/webroot/css/cake.css
+++ b/webroot/css/cake.css
@@ -1,5 +1,15 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Bebas+Neue:wght@400;700&display=swap');
+
+:root {
+    --legacy-sidebar-w: clamp(15rem, 18vw, 18rem);
+    --legacy-topbar-btn-w: clamp(5.25rem, 8.5vw, 8rem);
+    --legacy-topbar-icon-w: clamp(2rem, 3vw, 2.5rem);
+    --legacy-topbar-btn-h: clamp(2.15rem, 3vw, 2.5rem);
+    --legacy-topbar-font-size: clamp(0.78rem, 0.9vw, 1rem);
+    --legacy-topbar-gap: clamp(0.08rem, 0.35vw, 0.2rem);
+}
+
 body {
     font-family: "Roboto Condensed", sans-serif;
     font-weight: 400;
@@ -752,6 +762,7 @@ th.alt {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: var(--legacy-topbar-gap);
     height: 4rem;
     padding: 0 1rem;
     box-sizing: border-box;
@@ -771,7 +782,12 @@ th.alt {
 }
 .top-bar-botons {
     display: flex;
-    gap: 0.2rem; /* Espai entre botons */
+    flex: 1 1 auto;
+    min-width: 0;
+    gap: var(--legacy-topbar-gap); /* Espai entre botons */
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: thin;
 }
 
 .menu-opcions-mobile {
@@ -780,6 +796,30 @@ th.alt {
 }
 
 .mobile { display:none; }
+
+@media (min-width: 901px) and (max-width: 1200px) {
+  .top-bar {
+    padding: 0 0.35rem;
+  }
+
+  .top-bar-img {
+    flex: 0 0 auto;
+    max-width: var(--legacy-sidebar-w);
+    object-fit: contain;
+  }
+
+  .bototopbar,
+  .bototopbar-img {
+    white-space: normal;
+    text-wrap: balance;
+  }
+
+  .bototopbar a,
+  .bototopbar-img a {
+    font-size: inherit;
+    line-height: 1;
+  }
+}
 
 @media (max-width: 900px) {
   /* Replantegem la top-bar en grid per centrar el logo */
@@ -890,7 +930,7 @@ th.alt {
 
 .main {
     margin-top: 4rem; /* Espai per col·locar-se per sota de la top-bar */
-    margin-left: 10%; /* Espai per col·locar-se a la dreta de la sidebar */
+    margin-left: var(--legacy-sidebar-w); /* Espai per col·locar-se a la dreta de la sidebar */
     box-sizing: border-box;
     min-height: 85vh;
     max-height: 85vh;
@@ -921,7 +961,8 @@ th.alt {
     gap: 1vh;
     flex-wrap: wrap;
     flex-direction: column;
-    width: 10%;
+    width: var(--legacy-sidebar-w);
+    min-width: 15rem;
     height: calc(100vh - 4rem); /* Alçada restant per sota de la top-bar */
     position: fixed;
     top: 4rem; /* Per col·locar-la just sota la top-bar */
@@ -1189,11 +1230,12 @@ th.alt {
     display: flex;
     justify-content: center;
     align-items: center;
-    min-width: 8rem;
+    flex: 0 1 var(--legacy-topbar-btn-w);
+    min-width: var(--legacy-topbar-btn-w);
     max-width: 8rem;
-    max-height: 2.5rem;
-    min-height: 2.5rem;
-    margin:0.2rem;
+    max-height: var(--legacy-topbar-btn-h);
+    min-height: var(--legacy-topbar-btn-h);
+    margin: var(--legacy-topbar-gap);
     font-family: 'Bebas Neue', sans-serif;
     color: #ffffff;
     text-align: center;
@@ -1201,10 +1243,12 @@ th.alt {
     border: none;
     cursor: pointer;
     transition: transform 0.3s ease, box-shadow 0.3s ease; /* Suavitat en els efectes */
-    padding-left: 0.8rem;
-    padding-right: 0.8rem;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
+    padding-left: clamp(0.35rem, 0.7vw, 0.8rem);
+    padding-right: clamp(0.35rem, 0.7vw, 0.8rem);
+    padding-top: clamp(0.35rem, 0.55vw, 0.5rem);
+    padding-bottom: clamp(0.35rem, 0.55vw, 0.5rem);
+    font-size: var(--legacy-topbar-font-size);
+    line-height: 1;
     box-sizing: border-box;
 }
 
@@ -1219,11 +1263,12 @@ th.alt {
     display: flex;
     justify-content: space-between; /* Distribueix l'espai entre el text i la imatge */
     align-items: center; /* Centra verticalment */
-    min-width: 8rem;
+    flex: 0 1 var(--legacy-topbar-btn-w);
+    min-width: var(--legacy-topbar-btn-w);
     max-width: 8rem;
-    max-height: 2.5rem;
-    min-height: 2.5rem;
-    margin: 0.2rem;
+    max-height: var(--legacy-topbar-btn-h);
+    min-height: var(--legacy-topbar-btn-h);
+    margin: var(--legacy-topbar-gap);
     font-family: 'Bebas Neue', sans-serif;
     color: #ffffff;
     text-align: center;
@@ -1231,12 +1276,14 @@ th.alt {
     border: none;
     cursor: pointer;
     transition: transform 0.3s ease, box-shadow 0.3s ease; /* Suavitat en els efectes */
-    padding-left: 0.8rem;
-    padding-right: 0.8rem;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
+    padding-left: clamp(0.35rem, 0.7vw, 0.8rem);
+    padding-right: clamp(0.35rem, 0.7vw, 0.8rem);
+    padding-top: clamp(0.35rem, 0.55vw, 0.5rem);
+    padding-bottom: clamp(0.35rem, 0.55vw, 0.5rem);
+    font-size: var(--legacy-topbar-font-size);
+    line-height: 1;
     box-sizing: border-box;
-    margin-top: 0.2rem;
+    margin-top: var(--legacy-topbar-gap);
     margin-right: 0;
 }
 
@@ -1250,10 +1297,11 @@ th.alt {
     display: flex;
     justify-content: center;
     align-items: center;
-    min-width: 2.5rem;
+    flex: 0 0 var(--legacy-topbar-icon-w);
+    min-width: var(--legacy-topbar-icon-w);
     max-width: 2.5rem;
-    max-height: 2.5rem;
-    min-height: 2.5rem;
+    max-height: var(--legacy-topbar-btn-h);
+    min-height: var(--legacy-topbar-btn-h);
     font-family: 'Bebas Neue', sans-serif;
     color: #ffffff;
     text-align: center;
@@ -1275,6 +1323,7 @@ th.alt {
     gap: 0;
      display: flex;
      flex-direction: row;
+     flex: 0 0 auto;
 }
 
 .bototopbar-img a {


### PR DESCRIPTION
### Motivation
- Make the top-bar and sidebar layout responsive and scalable by replacing hardcoded sizes with adjustable variables and clamped values.
- Improve horizontal overflow handling for top-bar buttons and ensure consistent spacing across viewport sizes.
- Provide intermediate breakpoints for medium viewports to better control logo and button layout between mobile and desktop.

### Description
- Added a `:root` block with CSS custom properties such as `--legacy-sidebar-w`, `--legacy-topbar-btn-w`, `--legacy-topbar-icon-w`, `--legacy-topbar-btn-h`, `--legacy-topbar-font-size`, and `--legacy-topbar-gap` and switched many hardcoded widths/heights/gaps to use these variables in `webroot/css/cake.css`.
- Reworked top-bar and button styles to use flexible `flex` values, `clamp()` for paddings and font sizes, `line-height: 1`, and `overflow-x: auto` with `scrollbar-width: thin` for horizontal scrolling of buttons in narrow layouts.
- Replaced fixed sidebar and main offsets with `var(--legacy-sidebar-w)` and added a `min-width: 15rem` for the sidebar, and adjusted `.main` to use the sidebar variable for `margin-left`.
- Added a new media query for `@media (min-width: 901px) and (max-width: 1200px)` with tighter padding, constrained logo sizing, and typography adjustments to balance layout on medium screens.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a281afd2fb4832a94d206f808074969)